### PR TITLE
Add outcome forecasting analysis and tests

### DIFF
--- a/src/analysis/prediction_analysis.py
+++ b/src/analysis/prediction_analysis.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+"""Simple outcome forecasting based on historical governance data.
+
+Provides :func:`forecast_outcome` which estimates approval probability and
+expected voter turnout for a new referendum.  The function attempts to load
+historical OpenGov data via :func:`src.data_processing.data_loader.load_first_sheet`.
+If the Excel dataset is unavailable or lacks the required columns, sensible
+fallback values are returned.
+"""
+
+from typing import Dict, Any
+import pandas as pd
+
+from data_processing.data_loader import load_first_sheet
+
+
+def _mean_turnout(df: pd.DataFrame) -> float:
+    """Extract average turnout from the ``Voted_percentage`` column.
+
+    The dataset sometimes stores percentages as 0-100 or 0-1.  We normalise to a
+    0-1 range.
+    """
+    turnout = pd.to_numeric(df.get("Voted_percentage"), errors="coerce")
+    turnout = turnout.dropna()
+    if turnout.empty:
+        return 0.0
+    avg = float(turnout.mean())
+    # normalise if values appear to be 0-100
+    return avg / 100.0 if avg > 1 else avg
+
+
+def _approval_probability(df: pd.DataFrame) -> float:
+    """Compute proportion of referenda with status 'executed'."""
+    status = df.get("Status")
+    if status is None:
+        return 0.0
+    status = status.astype(str).str.lower()
+    return float((status == "executed").mean())
+
+
+def forecast_outcome(context: Dict[str, Any]) -> Dict[str, float]:
+    """Predict approval probability and voter turnout for a proposal.
+
+    Parameters
+    ----------
+    context : dict
+        Current pipeline context (unused but kept for future feature usage).
+
+    Returns
+    -------
+    dict
+        ``{"approval_probability": float, "turnout": float}`` – values are in
+        the 0-1 range.
+    """
+    try:
+        df = load_first_sheet()
+        approval = _approval_probability(df)
+        turnout = _mean_turnout(df)
+    except Exception:
+        # Fallback heuristics if historical data is unavailable
+        approval = 0.5
+        turnout = 0.3
+
+    return {
+        "approval_probability": round(float(approval), 3),
+        "turnout": round(float(turnout), 3),
+    }
+
+
+if __name__ == "__main__":
+    print(forecast_outcome({}))

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from data_processing.referenda_updater import update_referenda
 # from data_processing.blockchain_data_fetcher import fetch_recent_blocks
 from analysis.blockchain_metrics import summarise_blocks, load_blocks_from_file
 from analysis.governance_analysis import get_governance_insights
+from analysis.prediction_analysis import forecast_outcome
 from data_processing.blockchain_cache import get_recent_blocks_cached
 from llm.ollama_api import generate_completion
 
@@ -34,8 +35,9 @@ def build_prompt(context: dict) -> str:
         "You are an autonomous Polkadot governance agent. "
         "Draft a concise OpenGov proposal that (1) addresses current community "
         "sentiment and risks, (2) references recent on-chain activity, "
-        "(3) aligns with historical governance patterns, and "
-        "(4) is formatted for the 'Root' track including Title, Rationale, Action, "
+        "(3) aligns with historical governance patterns, (4) accounts for the "
+        "predicted approval probability and expected turnout, and (5) is "
+        "formatted for the 'Root' track including Title, Rationale, Action, "
         "and Expected Impact sections.\n\n"
         f"=== CONTEXT (JSON) ===\n{json.dumps(context, indent=2)}\n"
         "======================\n"
@@ -77,6 +79,9 @@ def main() -> None:
         "chain_kpis": chain_kpis,
         "governance_kpis": gov_kpis,
     }
+
+    # Forecast likely outcome using historical data
+    context["predictions"] = forecast_outcome(context)
     timestamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
     (OUT_DIR / f"context_{timestamp}.json").write_text(json.dumps(context, indent=2))
 

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -61,3 +61,13 @@ def validate_governance_kpis(d: Dict[str, Any]) -> bool:
     _require_keys(d, expected, "governance_kpis")
     return True
 
+
+def validate_predictions(d: Dict[str, Any]) -> bool:
+    """Ensure forecasting output contains probabilities in [0,1]."""
+    _require_keys(d, {"approval_probability", "turnout"}, "predictions")
+    if not (0 <= d["approval_probability"] <= 1):
+        raise ValueError("approval_probability outside [0,1]")
+    if not (0 <= d["turnout"] <= 1):
+        raise ValueError("turnout outside [0,1]")
+    return True
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,10 +1,14 @@
-"""
-pytest smoke tests – run `pytest -q`
+"""pytest smoke tests – run `pytest -q`.
+
 They skip external API calls by mocking the modules,
 so the tests are fast and deterministic.
 """
 
-from src.utils import validators as v
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from utils import validators as v
 
 
 def test_validators_pass_on_dummy():
@@ -32,7 +36,9 @@ def test_validators_pass_on_dummy():
         "monthly_counts": {},
         "top_keywords": [],
     }
+    preds = {"approval_probability": 0.6, "turnout": 0.4}
     assert v.validate_sentiment(sent)
     assert v.validate_news(news)
     assert v.validate_chain_kpis(chain)
     assert v.validate_governance_kpis(gov)
+    assert v.validate_predictions(preds)

--- a/tests/test_prediction_analysis.py
+++ b/tests/test_prediction_analysis.py
@@ -1,0 +1,14 @@
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from analysis.prediction_analysis import forecast_outcome
+from utils.validators import validate_predictions
+
+
+def test_forecast_outcome_structure_and_range():
+    result = forecast_outcome({})
+    # Ensure keys exist and values are within [0,1]
+    assert validate_predictions(result)
+    assert 0 <= result["approval_probability"] <= 1
+    assert 0 <= result["turnout"] <= 1


### PR DESCRIPTION
## Summary
- Implement `forecast_outcome` to estimate approval probability and expected turnout from historical governance data with graceful fallbacks
- Wire forecasting into the main pipeline and LLM prompt so proposals consider predicted outcomes
- Add validator and unit tests ensuring prediction outputs have the correct keys and ranges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68935c63e5948322b7cb51f534f50110