### PR TITLE
Integrate proposal submission workflow

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,1 @@
+# Agents package

--- a/src/agents/proposal_submission.py
+++ b/src/agents/proposal_submission.py
@@ -1,0 +1,80 @@
+"""Proposal submission utilities."""
+from __future__ import annotations
+
+import os
+from typing import Dict, Any, Optional
+
+import requests
+
+
+def _env_credentials() -> Dict[str, Any]:
+    """Collect submission credentials from environment variables."""
+    return {
+        "platform": os.getenv("PROPOSAL_PLATFORM", "snapshot"),
+        "api_url": os.getenv("SNAPSHOT_API_URL"),
+        "api_key": os.getenv("SNAPSHOT_API_KEY"),
+        "node_url": os.getenv("SUBSTRATE_NODE_URL"),
+        "private_key": os.getenv("SUBSTRATE_PRIVATE_KEY"),
+    }
+
+
+def submit_proposal(
+    proposal_text: str, credentials: Optional[Dict[str, Any]] = None
+) -> Optional[str]:
+    """Submit a proposal to a governance platform.
+
+    Parameters
+    ----------
+    proposal_text: str
+        The body of the proposal to submit.
+    credentials: dict, optional
+        Authentication and target information. If omitted, values are read
+        from environment variables.
+
+    Returns
+    -------
+    Optional[str]
+        Identifier returned by the platform, such as transaction hash or URL,
+        or ``None`` if submission fails.
+    """
+    creds = credentials or _env_credentials()
+    platform = creds.get("platform", "snapshot")
+
+    try:
+        if platform == "snapshot":
+            api_url = creds.get("api_url")
+            if not api_url:
+                raise ValueError("'api_url' missing for snapshot submission")
+            headers = {}
+            api_key = creds.get("api_key")
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            payload = {"proposal": proposal_text}
+            response = requests.post(api_url, json=payload, headers=headers, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            return data.get("tx_hash") or data.get("url") or data.get("id")
+
+        if platform == "substrate":
+            from substrateinterface import SubstrateInterface, Keypair
+
+            node_url = creds.get("node_url")
+            private_key = creds.get("private_key")
+            if not (node_url and private_key):
+                raise ValueError(
+                    "'node_url' and 'private_key' required for substrate submission"
+                )
+            substrate = SubstrateInterface(url=node_url)
+            keypair = Keypair.create_from_private_key(private_key)
+            call = substrate.compose_call(
+                call_module=creds.get("call_module", "Referenda"),
+                call_function=creds.get("call_function", "submit"),
+                call_params=creds.get("call_params", {"proposal": proposal_text}),
+            )
+            extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
+            receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
+            return receipt.extrinsic_hash
+    except Exception:
+        return None
+
+    return None

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ $ python src/main.py
 """
 
 from __future__ import annotations
-import json, pathlib, datetime as dt
+import json, pathlib, datetime as dt, os
 from utils.helpers import utc_now_iso
 from data_processing.social_media_scraper import collect_recent_messages
 from analysis.sentiment_analysis import analyse_messages
@@ -20,6 +20,7 @@ from analysis.blockchain_metrics import summarise_blocks, load_blocks_from_file
 from analysis.governance_analysis import get_governance_insights
 from data_processing.blockchain_cache import get_recent_blocks_cached
 from llm.ollama_api import generate_completion
+from agents.proposal_submission import submit_proposal
 
 
 # --- main.py  (top of file) -----------------------------------------------
@@ -90,6 +91,11 @@ def main() -> None:
     )
     timestamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
     (OUT_DIR / f"proposal_{timestamp}.txt").write_text(proposal_text)
+    submission_id = submit_proposal(proposal_text)
+    if submission_id:
+        print(f"🔗 Proposal submitted → {submission_id}")
+    else:
+        print("⚠️ Submission failed")
 
     duration = (dt.datetime.utcnow() - start).total_seconds()
     print(f"\n✅ Proposal saved → {OUT_DIR/'proposal_latest.txt'}   "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys, pathlib
+root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.extend([str(root), str(root / "src")])

--- a/tests/test_proposal_submission.py
+++ b/tests/test_proposal_submission.py
@@ -1,0 +1,80 @@
+from src.agents.proposal_submission import submit_proposal
+
+
+def test_submit_proposal_http(monkeypatch):
+    """Snapshot-style HTTP submission returns identifier."""
+    def fake_post(url, json=None, headers=None, timeout=10):
+        assert url == "https://snapshot.fake/api"
+        assert json["proposal"] == "hello"
+        assert headers["Authorization"] == "Bearer key"
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"url": "https://snapshot.fake/p/1"}
+        return Resp()
+    monkeypatch.setattr("requests.post", fake_post)
+    creds = {"api_url": "https://snapshot.fake/api", "api_key": "key"}
+    res = submit_proposal("hello", creds)
+    assert res == "https://snapshot.fake/p/1"
+
+
+def test_submit_proposal_env(monkeypatch):
+    """Environment variables supply credentials when none passed."""
+    def fake_post(url, json=None, headers=None, timeout=10):
+        assert url == "https://snapshot.fake/api"
+        assert json["proposal"] == "hi"
+        assert headers["Authorization"] == "Bearer key"
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"url": "https://snapshot.fake/p/2"}
+        return Resp()
+    monkeypatch.setattr("requests.post", fake_post)
+    monkeypatch.setenv("PROPOSAL_PLATFORM", "snapshot")
+    monkeypatch.setenv("SNAPSHOT_API_URL", "https://snapshot.fake/api")
+    monkeypatch.setenv("SNAPSHOT_API_KEY", "key")
+    res = submit_proposal("hi")
+    assert res == "https://snapshot.fake/p/2"
+
+
+def test_main_submits(monkeypatch, capsys):
+    """Pipeline integrates submission step."""
+    import types, sys
+    # Stub heavy dependencies before importing main
+    pandas_module = types.ModuleType("pandas")
+    pandas_module.DataFrame = type("DataFrame", (), {})
+    pandas_module.read_excel = lambda *a, **k: pandas_module.DataFrame()
+    sys.modules.setdefault("pandas", pandas_module)
+    bs4_module = types.ModuleType("bs4")
+    bs4_module.BeautifulSoup = object
+    sys.modules.setdefault("bs4", bs4_module)
+    feedparser_module = types.ModuleType("feedparser")
+    feedparser_module.parse = lambda *a, **k: types.SimpleNamespace(entries=[])
+    sys.modules.setdefault("feedparser", feedparser_module)
+    numpy_module = types.ModuleType("numpy")
+    sys.modules.setdefault("numpy", numpy_module)
+    substrate_module = types.ModuleType("substrateinterface")
+    substrate_module.SubstrateInterface = object
+    sys.modules.setdefault("substrateinterface", substrate_module)
+
+    import src.main as main
+
+    monkeypatch.setattr(main, "collect_recent_messages", lambda: [])
+    monkeypatch.setattr(main, "analyse_messages", lambda msgs: {})
+    monkeypatch.setattr(main, "fetch_and_summarise_news", lambda: {})
+    monkeypatch.setattr(main, "update_referenda", lambda max_new=500: None)
+    monkeypatch.setattr(main, "get_recent_blocks_cached", lambda: [])
+    monkeypatch.setattr(main, "summarise_blocks", lambda blocks: {})
+    monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
+    monkeypatch.setattr(main, "generate_completion", lambda **kwargs: "proposal text")
+
+    def fake_submit(text, credentials=None):
+        assert text == "proposal text"
+        return "abc123"
+    monkeypatch.setattr(main, "submit_proposal", fake_submit)
+
+    main.main()
+    out = capsys.readouterr().out
+    assert "abc123" in out


### PR DESCRIPTION
## Summary
- move credential gathering and submission handling into agent
- simplify main to delegate proposal submission
- extend tests for env-driven credentials and pipeline integration

## Testing
- `pytest -q`
