### PR TITLE
Add Polkadot OpenGov governor interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,15 @@ Create a `.env` file in the project root:
  Optional: NEWS_API_KEY=your_news_api_key
  REDDIT_CLIENT_ID=...
  REDDIT_CLIENT_SECRET=...
+ SUBSTRATE_NODE_URL=wss://rpc.polkadot.io
+ SUBSTRATE_PRIVATE_KEY=hex_encoded_sr25519_key
 ```
+
+`SUBSTRATE_NODE_URL` should point to a Substrate RPC endpoint. Common choices
+include `wss://rpc.polkadot.io` for Polkadot mainnet or
+`wss://westend-rpc.polkadot.io` for the Westend testnet. The
+`SUBSTRATE_PRIVATE_KEY` is the signing key used by the execution agent when
+submitting OpenGov transactions and must be funded for deposits.
 
 ---
 

--- a/src/execution/governor_interface.py
+++ b/src/execution/governor_interface.py
@@ -1,0 +1,90 @@
+"""Polkadot OpenGov interaction utilities."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def connect(node_url: str):
+    """Return a ``SubstrateInterface`` connection to ``node_url``.
+
+    Parameters
+    ----------
+    node_url: str
+        WebSocket/HTTP endpoint of the Substrate node.
+    """
+    from substrateinterface import SubstrateInterface  # local import for testability
+
+    return SubstrateInterface(url=node_url)
+
+
+def _create_keypair(private_key: str):
+    """Create a ``Keypair`` from a raw private key."""
+    from substrateinterface import Keypair  # local import for testability
+
+    return Keypair.create_from_private_key(private_key)
+
+
+def submit_preimage(node_url: str, private_key: str, preimage: bytes) -> Dict[str, Any]:
+    """Submit a preimage to the chain and return receipt details."""
+    substrate = connect(node_url)
+    keypair = _create_keypair(private_key)
+    call = substrate.compose_call(
+        call_module="Preimage",
+        call_function="note_preimage",
+        call_params={"bytes": preimage},
+    )
+    extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
+    receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
+    return parse_receipt(receipt)
+
+
+def submit_proposal(
+    node_url: str, private_key: str, preimage_hash: str, track_id: int, value: int
+) -> Dict[str, Any]:
+    """Submit a referendum proposal referencing an existing preimage."""
+    substrate = connect(node_url)
+    keypair = _create_keypair(private_key)
+    call = substrate.compose_call(
+        call_module="Referenda",
+        call_function="submit",
+        call_params={
+            "proposal": preimage_hash,
+            "track": track_id,
+            "value": value,
+        },
+    )
+    extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
+    receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
+    return parse_receipt(receipt)
+
+
+def query_proposal_status(node_url: str, referendum_index: int) -> Optional[str]:
+    """Return a simple status string for ``referendum_index`` or ``None``."""
+    substrate = connect(node_url)
+    info = substrate.query(
+        module="Referenda", storage_function="ReferendumInfoFor", params=[referendum_index]
+    )
+    value = getattr(info, "value", None)
+    if not value:
+        return None
+    if isinstance(value, dict):
+        if "Ongoing" in value:
+            return value["Ongoing"].get("status")
+        if "Approved" in value:
+            return "Approved"
+        if "Rejected" in value:
+            return "Rejected"
+        if "Cancelled" in value:
+            return "Cancelled"
+    return str(value)
+
+
+def parse_receipt(receipt: Any) -> Dict[str, Any]:
+    """Convert a substrate receipt into a simple dictionary."""
+    return {
+        "extrinsic_hash": getattr(receipt, "extrinsic_hash", None),
+        "block_hash": getattr(receipt, "block_hash", None),
+        "is_success": getattr(receipt, "is_success", False),
+        "error_message": getattr(receipt, "error_message", None),
+    }
+

--- a/tests/test_governor_interface.py
+++ b/tests/test_governor_interface.py
@@ -1,0 +1,98 @@
+"""Tests for the Polkadot OpenGov governor interface."""
+from types import SimpleNamespace
+
+import src.execution.governor_interface as gi
+
+
+def test_submit_preimage(monkeypatch):
+    """Submitting a preimage composes the correct call and parses receipt."""
+    class FakeSubstrate:
+        def compose_call(self, call_module, call_function, call_params):
+            assert call_module == "Preimage"
+            assert call_function == "note_preimage"
+            assert call_params["bytes"] == b"data"
+            return "call"
+
+        def create_signed_extrinsic(self, call, keypair):
+            assert call == "call"
+            assert keypair == "kp"
+            return "xt"
+
+        def submit_extrinsic(self, extrinsic, wait_for_inclusion):
+            assert extrinsic == "xt"
+            assert wait_for_inclusion is True
+            return SimpleNamespace(
+                extrinsic_hash="0xabc", block_hash="0xdef", is_success=True, error_message=None
+            )
+
+    monkeypatch.setattr(gi, "connect", lambda url: FakeSubstrate())
+    monkeypatch.setattr(gi, "_create_keypair", lambda pk: "kp")
+    receipt = gi.submit_preimage("ws://node", "priv", b"data")
+    assert receipt == {
+        "extrinsic_hash": "0xabc",
+        "block_hash": "0xdef",
+        "is_success": True,
+        "error_message": None,
+    }
+
+
+def test_submit_proposal(monkeypatch):
+    """Submitting a proposal references preimage hash and track."""
+    class FakeSubstrate:
+        def compose_call(self, call_module, call_function, call_params):
+            assert call_module == "Referenda"
+            assert call_function == "submit"
+            assert call_params == {
+                "proposal": "0x01",
+                "track": 1,
+                "value": 10,
+            }
+            return "call"
+
+        def create_signed_extrinsic(self, call, keypair):
+            assert call == "call"
+            assert keypair == "kp"
+            return "xt"
+
+        def submit_extrinsic(self, extrinsic, wait_for_inclusion):
+            assert extrinsic == "xt"
+            return SimpleNamespace(
+                extrinsic_hash="0x1", block_hash="0x2", is_success=False, error_message="fail"
+            )
+
+    monkeypatch.setattr(gi, "connect", lambda url: FakeSubstrate())
+    monkeypatch.setattr(gi, "_create_keypair", lambda pk: "kp")
+    receipt = gi.submit_proposal("ws://node", "priv", "0x01", 1, 10)
+    assert receipt["extrinsic_hash"] == "0x1"
+    assert receipt["is_success"] is False
+    assert receipt["error_message"] == "fail"
+
+
+def test_query_proposal_status(monkeypatch):
+    """Status helper extracts state from storage query."""
+    class FakeSubstrate:
+        def query(self, module, storage_function, params):
+            assert module == "Referenda"
+            assert storage_function == "ReferendumInfoFor"
+            assert params == [5]
+            return SimpleNamespace(value={"Ongoing": {"status": "Deciding"}})
+
+    monkeypatch.setattr(gi, "connect", lambda url: FakeSubstrate())
+    status = gi.query_proposal_status("ws://node", 5)
+    assert status == "Deciding"
+
+
+def test_parse_receipt():
+    """Receipt parser flattens receipt attributes."""
+    receipt = SimpleNamespace(
+        extrinsic_hash="0x3",
+        block_hash="0x4",
+        is_success=True,
+        error_message=None,
+    )
+    assert gi.parse_receipt(receipt) == {
+        "extrinsic_hash": "0x3",
+        "block_hash": "0x4",
+        "is_success": True,
+        "error_message": None,
+    }


### PR DESCRIPTION
## Summary
- add `governor_interface` module for submitting Polkadot OpenGov extrinsics
- helper utilities for proposal status queries and receipt parsing
- document required Substrate RPC endpoint and signing key in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689379f7465483229a7ba94acbdf77d0