### PR TITLE
feat: add social platform connectors

### DIFF
--- a/src/execution/discord_bot.py
+++ b/src/execution/discord_bot.py
@@ -1,0 +1,29 @@
+"""Simple Discord connector to post proposal summaries via webhooks."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import requests
+
+
+def post_summary(summary: str, webhook_url: Optional[str] = None) -> bool:
+    """Post ``summary`` to Discord using a webhook URL.
+
+    Parameters
+    ----------
+    summary: str
+        The message to send.
+    webhook_url: Optional[str]
+        Explicit webhook URL. If ``None``, uses ``DISCORD_WEBHOOK_URL`` env var.
+
+    Returns
+    -------
+    bool
+        ``True`` if the request was sent successfully, ``False`` otherwise.
+    """
+    url = webhook_url or os.getenv("DISCORD_WEBHOOK_URL")
+    if not url:
+        return False
+    resp = requests.post(url, json={"content": summary})
+    return resp.ok

--- a/src/execution/telegram_bot.py
+++ b/src/execution/telegram_bot.py
@@ -1,0 +1,37 @@
+"""Telegram connector to post proposal summaries via bot API."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import requests
+
+
+def post_summary(
+    summary: str,
+    token: Optional[str] = None,
+    chat_id: Optional[str] = None,
+) -> bool:
+    """Send ``summary`` to Telegram chat using Bot API.
+
+    Parameters
+    ----------
+    summary: str
+        Message content to send.
+    token: Optional[str]
+        Bot token. If ``None``, uses ``TELEGRAM_BOT_TOKEN`` env var.
+    chat_id: Optional[str]
+        Target chat ID. If ``None``, uses ``TELEGRAM_CHAT_ID`` env var.
+
+    Returns
+    -------
+    bool
+        ``True`` if the request was sent successfully, ``False`` otherwise.
+    """
+    token = token or os.getenv("TELEGRAM_BOT_TOKEN")
+    chat_id = chat_id or os.getenv("TELEGRAM_CHAT_ID")
+    if not token or not chat_id:
+        return False
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    resp = requests.post(url, json={"chat_id": chat_id, "text": summary})
+    return resp.ok

--- a/src/execution/twitter_bot.py
+++ b/src/execution/twitter_bot.py
@@ -1,0 +1,31 @@
+"""Twitter connector to post proposal summaries via API v2."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import requests
+
+
+def post_summary(summary: str, bearer_token: Optional[str] = None) -> bool:
+    """Post ``summary`` to Twitter using API v2 ``/tweets`` endpoint.
+
+    Parameters
+    ----------
+    summary: str
+        Tweet text.
+    bearer_token: Optional[str]
+        API bearer token. If ``None``, uses ``TWITTER_BEARER`` env var.
+
+    Returns
+    -------
+    bool
+        ``True`` if the request was sent successfully, ``False`` otherwise.
+    """
+    token = bearer_token or os.getenv("TWITTER_BEARER")
+    if not token:
+        return False
+    url = "https://api.twitter.com/2/tweets"
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.post(url, json={"text": summary}, headers=headers)
+    return resp.ok

--- a/tests/test_platform_connectors.py
+++ b/tests/test_platform_connectors.py
@@ -1,0 +1,36 @@
+"""Tests for social platform connector payloads."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import src.execution.discord_bot as discord_bot
+import src.execution.telegram_bot as telegram_bot
+import src.execution.twitter_bot as twitter_bot
+
+
+def test_discord_payload():
+    with patch("src.execution.discord_bot.requests.post") as post:
+        post.return_value.ok = True
+        assert discord_bot.post_summary("hello", webhook_url="url") is True
+        post.assert_called_once_with("url", json={"content": "hello"})
+
+
+def test_telegram_payload():
+    with patch("src.execution.telegram_bot.requests.post") as post:
+        post.return_value.ok = True
+        assert telegram_bot.post_summary("hi", token="TOKEN", chat_id="c") is True
+        post.assert_called_once_with(
+            "https://api.telegram.org/botTOKEN/sendMessage",
+            json={"chat_id": "c", "text": "hi"},
+        )
+
+
+def test_twitter_payload():
+    with patch("src.execution.twitter_bot.requests.post") as post:
+        post.return_value.ok = True
+        assert twitter_bot.post_summary("tweet", bearer_token="tok") is True
+        post.assert_called_once_with(
+            "https://api.twitter.com/2/tweets",
+            json={"text": "tweet"},
+            headers={"Authorization": "Bearer tok"},
+        )


### PR DESCRIPTION
## Summary
- add Discord, Telegram, and Twitter connector modules to post proposal summaries
- broadcast proposals to configured social platforms in main pipeline
- test payload formatting for each social connector

## Testing
- `pytest -q`
