### PR TITLE
feat: log proposals and execution results

### DIFF
--- a/src/data_processing/data_loader.py
+++ b/src/data_processing/data_loader.py
@@ -41,6 +41,22 @@ def load_first_sheet() -> pd.DataFrame:
     return df
 
 
+def load_proposals() -> pd.DataFrame:
+    """Return the ``Proposals`` worksheet as a DataFrame (empty if missing)."""
+    try:
+        return load_governance_data(sheet_name="Proposals")
+    except Exception:
+        return pd.DataFrame()
+
+
+def load_execution_results() -> pd.DataFrame:
+    """Return the ``ExecutionResults`` worksheet as a DataFrame (empty if missing)."""
+    try:
+        return load_governance_data(sheet_name="ExecutionResults")
+    except Exception:
+        return pd.DataFrame()
+
+
 # Quick test
 if __name__ == "__main__":
     dfs = load_governance_data()  # Load all sheets by default

--- a/src/data_processing/proposal_store.py
+++ b/src/data_processing/proposal_store.py
@@ -1,0 +1,89 @@
+"""Utilities for storing proposals and execution results in the governance workbook."""
+from __future__ import annotations
+
+import pathlib
+from typing import Dict, Any
+
+from utils.helpers import utc_now_iso
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+DATA_DIR = ROOT / "data"
+XLSX_PATH = DATA_DIR / "input" / "PKD Governance Data.xlsx"
+
+
+def _append_row(sheet: str, row: Dict[str, Any]) -> None:
+    """Append a dictionary ``row`` to ``sheet`` creating workbook/sheet if needed."""
+    try:
+        from openpyxl import load_workbook, Workbook  # type: ignore
+    except Exception:
+        # Openpyxl (or its deps) not available – skip persistence silently
+        return
+
+    XLSX_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if XLSX_PATH.exists():
+        wb = load_workbook(XLSX_PATH)
+    else:
+        wb = Workbook()
+    ws = wb[sheet] if sheet in wb.sheetnames else wb.create_sheet(sheet)
+    # Write header if sheet empty
+    if ws.max_row == 1 and all(cell.value is None for cell in ws[1]):
+        ws.delete_rows(1)
+        ws.append(list(row.keys()))
+    elif ws.max_row == 0:
+        ws.append(list(row.keys()))
+    ws.append([row.get(col, "") for col in ws[1]])
+    wb.save(XLSX_PATH)
+
+
+def record_proposal(proposal_text: str, submission_id: str | None) -> None:
+    """Record a generated proposal and optional submission identifier."""
+    row = {
+        "timestamp": utc_now_iso(),
+        "proposal_text": proposal_text,
+        "submission_id": submission_id or "",
+    }
+    _append_row("Proposals", row)
+
+
+def record_execution_result(
+    status: str,
+    block_hash: str,
+    outcome: str,
+    submission_id: str | None = None,
+) -> None:
+    """Append governor execution details to the ``ExecutionResults`` sheet."""
+    row = {
+        "timestamp": utc_now_iso(),
+        "submission_id": submission_id or "",
+        "status": status,
+        "block_hash": block_hash,
+        "outcome": outcome,
+    }
+    _append_row("ExecutionResults", row)
+
+
+# Reading helpers -----------------------------------------------------------
+
+
+def load_proposals():
+    """Read the ``Proposals`` sheet as a DataFrame (empty if unavailable)."""
+    import pandas as pd
+
+    if not XLSX_PATH.exists():
+        return pd.DataFrame()
+    try:
+        return pd.read_excel(XLSX_PATH, sheet_name="Proposals")
+    except Exception:
+        return pd.DataFrame()
+
+
+def load_execution_results():
+    """Read the ``ExecutionResults`` sheet as a DataFrame (empty if unavailable)."""
+    import pandas as pd
+
+    if not XLSX_PATH.exists():
+        return pd.DataFrame()
+    try:
+        return pd.read_excel(XLSX_PATH, sheet_name="ExecutionResults")
+    except Exception:
+        return pd.DataFrame()

--- a/src/data_processing/referenda_updater.py
+++ b/src/data_processing/referenda_updater.py
@@ -294,7 +294,13 @@ def update_referenda(max_new: int = 500, max_gaps: int = 5) -> None:
     # persist results
     print(f"Stopped after {attempted} attempts (gaps {gap_streak}/{max_gaps}).")
     XLSX_PATH.parent.mkdir(parents=True, exist_ok=True)
-    df.to_excel(XLSX_PATH, index=False)
+    if XLSX_PATH.exists():
+        with pd.ExcelWriter(
+            XLSX_PATH, engine="openpyxl", mode="a", if_sheet_exists="replace"
+        ) as writer:
+            df.to_excel(writer, sheet_name="Referenda", index=False)
+    else:
+        df.to_excel(XLSX_PATH, sheet_name="Referenda", index=False)
     print(f"✔ Workbook updated → {XLSX_PATH}")
 
     if failures:

--- a/src/main.py
+++ b/src/main.py
@@ -24,6 +24,10 @@ from agents.proposal_submission import submit_proposal
 from execution.discord_bot import post_summary as post_discord
 from execution.telegram_bot import post_summary as post_telegram
 from execution.twitter_bot import post_summary as post_twitter
+from data_processing.proposal_store import (
+    record_proposal,
+    record_execution_result,
+)
 
 
 # --- main.py  (top of file) -----------------------------------------------
@@ -111,10 +115,23 @@ def main() -> None:
     (OUT_DIR / f"proposal_{timestamp}.txt").write_text(proposal_text)
     broadcast_proposal(proposal_text)
     submission_id = submit_proposal(proposal_text)
+    record_proposal(proposal_text, submission_id)
     if submission_id:
         print(f"🔗 Proposal submitted → {submission_id}")
+        record_execution_result(
+            status="submitted",
+            block_hash=submission_id,
+            outcome="pending",
+            submission_id=submission_id,
+        )
     else:
         print("⚠️ Submission failed")
+        record_execution_result(
+            status="failed",
+            block_hash="",
+            outcome="error",
+            submission_id=None,
+        )
 
     duration = (dt.datetime.utcnow() - start).total_seconds()
     print(f"\n✅ Proposal saved → {OUT_DIR/'proposal_latest.txt'}   "


### PR DESCRIPTION
## Summary
- add workbook sheets to track proposals and execution outcomes
- capture proposals and execution metadata during pipeline run
- expose helpers to read stored proposal and execution history
- remove bundled governance workbook from version control

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893904298a083228c7ecf42cf75c78c