### PR TITLE
Add context generation and persistence utilities

### DIFF
--- a/src/agents/context_generator.py
+++ b/src/agents/context_generator.py
@@ -1,0 +1,22 @@
+"""Context generation utilities."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from utils.helpers import utc_now_iso
+
+
+def build_context(
+    sentiment: Dict[str, Any],
+    news: Dict[str, Any],
+    chain_kpis: Dict[str, Any],
+    gov_kpis: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Consolidate disparate inputs into a single context dictionary."""
+    return {
+        "timestamp_utc": utc_now_iso(),
+        "sentiment": sentiment,
+        "news": news,
+        "chain_kpis": chain_kpis,
+        "governance_kpis": gov_kpis,
+    }

--- a/src/data_processing/proposal_store.py
+++ b/src/data_processing/proposal_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pathlib
 from typing import Dict, Any
+import json
 
 from src.utils.helpers import utc_now_iso
 
@@ -31,7 +32,7 @@ def _append_row(sheet: str, row: Dict[str, Any]) -> None:
         ws.append(list(row.keys()))
     elif ws.max_row == 0:
         ws.append(list(row.keys()))
-    ws.append([row.get(col, "") for col in ws[1]])
+    ws.append([row.get(col.value, "") for col in ws[1]])
     wb.save(XLSX_PATH)
 
 
@@ -60,6 +61,15 @@ def record_execution_result(
         "outcome": outcome,
     }
     _append_row("ExecutionResults", row)
+
+
+def record_context(context_dict: Dict[str, Any]) -> None:
+    """Record consolidated context blob for auditing."""
+    row = {
+        "timestamp": utc_now_iso(),
+        "context_json": json.dumps(context_dict),
+    }
+    _append_row("Context", row)
 
 
 # Reading helpers -----------------------------------------------------------

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -1,0 +1,63 @@
+import json
+from src.agents.context_generator import build_context
+from src.data_processing import proposal_store
+from src.utils import validators as v
+
+
+def _dummy_components():
+    sentiment = {"sentiment_score": 0, "summary": "ok", "key_topics": []}
+    news = {"digest": [], "risks": ""}
+    chain = {
+        "daily_tx_count": {},
+        "daily_total_fees_DOT": {},
+        "avg_tx_per_block": 0,
+        "avg_fee_per_tx_DOT": 0,
+        "busiest_hour_utc": "",
+    }
+    gov = {
+        "total_referenda": 0,
+        "executed_pct": 0,
+        "rejected_pct": 0,
+        "avg_turnout_pct": 0,
+        "median_turnout_pct": 0,
+        "avg_participants": 0,
+        "avg_duration_days": 0,
+        "monthly_counts": {},
+        "top_keywords": [],
+    }
+    return sentiment, news, chain, gov
+
+
+def test_build_context_structure():
+    sentiment, news, chain, gov = _dummy_components()
+    ctx = build_context(sentiment, news, chain, gov)
+    assert set(ctx.keys()) == {
+        "timestamp_utc",
+        "sentiment",
+        "news",
+        "chain_kpis",
+        "governance_kpis",
+    }
+    assert v.validate_sentiment(ctx["sentiment"])
+    assert v.validate_news(ctx["news"])
+    assert v.validate_chain_kpis(ctx["chain_kpis"])
+    assert v.validate_governance_kpis(ctx["governance_kpis"])
+
+
+def test_record_context_persist(tmp_path, monkeypatch):
+    sentiment, news, chain, gov = _dummy_components()
+    ctx = build_context(sentiment, news, chain, gov)
+    monkeypatch.setattr(proposal_store, "XLSX_PATH", tmp_path / "gov.xlsx")
+    proposal_store.record_context(ctx)
+    from openpyxl import load_workbook
+
+    wb = load_workbook(proposal_store.XLSX_PATH)
+    ws = wb["Context"]
+    rows = list(ws.iter_rows(values_only=True))
+    # header then one row
+    assert rows[0] == ("timestamp", "context_json")
+    stored = json.loads(rows[1][1])
+    assert stored["sentiment"] == sentiment
+    assert stored["news"] == news
+    assert stored["chain_kpis"] == chain
+    assert stored["governance_kpis"] == gov

--- a/tests/test_proposal_submission.py
+++ b/tests/test_proposal_submission.py
@@ -69,6 +69,7 @@ def test_main_submits(monkeypatch, capsys):
     monkeypatch.setattr(main, "summarise_blocks", lambda blocks: {})
     monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
     monkeypatch.setattr(main, "generate_completion", lambda **kwargs: "proposal text")
+    monkeypatch.setattr(main, "record_context", lambda ctx: None)
 
     def fake_submit(text, credentials=None):
         assert text == "proposal text"


### PR DESCRIPTION
## Summary
- add `build_context` agent consolidating sentiment, news, and KPI inputs
- persist context snapshots via `record_context` and integrate into pipeline
- test context building and storage, and adjust existing pipeline test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c79964b88322b55b1ba357bde162