### PR TITLE
Add referendum outcome predictions

### DIFF
--- a/src/analysis/prediction_analysis.py
+++ b/src/analysis/prediction_analysis.py
@@ -1,0 +1,60 @@
+import pandas as pd
+from typing import Dict
+
+from src.data_processing.data_loader import load_governance_data
+
+
+def forecast_outcomes(context: Dict) -> Dict[str, float]:
+    """Return naive forecasts for upcoming referendum outcomes.
+
+    The function inspects historical referendum data stored in the
+    ``PKD Governance Data.xlsx`` workbook and computes two simple metrics:
+
+    ``approval_prob``
+        Fraction of past referenda that executed successfully.
+    ``turnout_estimate``
+        Average voter turnout (participants / eligible) across historical
+        referenda.
+
+    Parameters
+    ----------
+    context: dict
+        Unused currently but kept for future model features.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``approval_prob`` and ``turnout_estimate`` keys.
+    """
+    try:
+        df = load_governance_data(sheet_name="Referenda")
+    except Exception:
+        df = pd.DataFrame()
+
+    approval_prob = 0.5
+    turnout_estimate = 0.0
+
+    try:
+        if not df.empty:
+            # Approval probability: share of executed referenda
+            if "Status" in df.columns and len(df):
+                approved = df["Status"].astype(str).str.lower().eq("executed").sum()
+                approval_prob = approved / len(df)
+            # Turnout: either provided percentage or compute from counts
+            if "Voted_percentage" in df.columns:
+                turnout_estimate = df["Voted_percentage"].astype(float).mean() / 100.0
+            elif {"Participants", "Eligible_DOT"}.issubset(df.columns):
+                turnout_estimate = (
+                    (df["Participants"].astype(float) / df["Eligible_DOT"].replace(0, pd.NA))
+                    .fillna(0)
+                    .mean()
+                )
+    except Exception:
+        pass
+
+    approval_prob = float(max(0.0, min(1.0, approval_prob)))
+    turnout_estimate = float(max(0.0, min(1.0, turnout_estimate)))
+    return {
+        "approval_prob": approval_prob,
+        "turnout_estimate": turnout_estimate,
+    }

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from data_processing.referenda_updater import update_referenda
 # from data_processing.blockchain_data_fetcher import fetch_recent_blocks
 from analysis.blockchain_metrics import summarise_blocks, load_blocks_from_file
 from analysis.governance_analysis import get_governance_insights
+from analysis.prediction_analysis import forecast_outcomes
 from data_processing.blockchain_cache import get_recent_blocks_cached
 from llm.ollama_api import generate_completion
 from agents.proposal_submission import submit_proposal
@@ -95,6 +96,8 @@ def main() -> None:
 
     # Bundle context via agent
     context = build_context(sentiment, news, chain_kpis, gov_kpis)
+    forecast = forecast_outcomes(context)
+    context["forecast"] = forecast
     timestamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
     (OUT_DIR / f"context_{timestamp}.json").write_text(json.dumps(context, indent=2))
     record_context(context)

--- a/tests/test_prediction_analysis.py
+++ b/tests/test_prediction_analysis.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from src.analysis.prediction_analysis import forecast_outcomes
+from src.data_processing import data_loader
+
+
+def test_forecast_outcomes_fields_and_ranges(tmp_path, monkeypatch):
+    df = pd.DataFrame(
+        {
+            "Status": ["Executed", "Rejected"],
+            "Voted_percentage": [60.0, 40.0],
+            "Participants": [100, 80],
+            "Eligible_DOT": [200, 200],
+        }
+    )
+    path = tmp_path / "PKD Governance Data.xlsx"
+    df.to_excel(path, sheet_name="Referenda", index=False)
+    monkeypatch.setattr(data_loader, "FILE_PATH", path)
+
+    result = forecast_outcomes({})
+    assert set(result.keys()) == {"approval_prob", "turnout_estimate"}
+    assert 0.0 <= result["approval_prob"] <= 1.0
+    assert 0.0 <= result["turnout_estimate"] <= 1.0
+    assert round(result["approval_prob"], 2) == 0.5
+    assert round(result["turnout_estimate"], 2) == 0.5


### PR DESCRIPTION
## Summary
- implement `forecast_outcomes` to estimate approval probability and turnout using historical referenda workbook
- include outcome forecasts in pipeline context and prompt
- test prediction outputs for required fields and valid ranges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894cba601e483229e8c73435059e75f