### PR TITLE
Refactor proposal drafting into dedicated agent

### DIFF
--- a/src/agents/proposal_generator.py
+++ b/src/agents/proposal_generator.py
@@ -1,0 +1,34 @@
+"""Proposal drafting utilities."""
+from __future__ import annotations
+
+import json
+from typing import Dict, Any
+
+from llm import ollama_api
+
+
+def build_prompt(context: Dict[str, Any]) -> str:
+    """Compose a single prompt for the LLM with all context JSON."""
+    return (
+        "You are an autonomous Polkadot governance agent. "
+        "Draft a concise OpenGov proposal that (1) addresses current community "
+        "sentiment and risks, (2) references recent on-chain activity, "
+        "(3) aligns with historical governance patterns, and "
+        "(4) is formatted for the 'Root' track including Title, Rationale, Action, "
+        "and Expected Impact sections.\n\n"
+        f"=== CONTEXT (JSON) ===\n{json.dumps(context, indent=2)}\n"
+        "======================\n"
+        "Return ONLY the proposal text, no JSON."
+    )
+
+
+def draft(context_dict: Dict[str, Any]) -> str:
+    """Return a proposal generated from ``context_dict``."""
+    prompt = build_prompt(context_dict)
+    return ollama_api.generate_completion(
+        prompt=prompt,
+        system="You are Polkadot-Gov-Agent v1.",
+        model="gemma3:4b",
+        temperature=0.3,
+        max_tokens=2048,
+    )

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -1,7 +1,24 @@
-import src.main as main
-
-
 def test_main_records_final_status(monkeypatch, tmp_path):
+    import types, sys
+    # Stub heavy dependencies before importing main
+    pandas_module = types.ModuleType("pandas")
+    pandas_module.DataFrame = type("DataFrame", (), {})
+    pandas_module.read_excel = lambda *a, **k: pandas_module.DataFrame()
+    sys.modules.setdefault("pandas", pandas_module)
+    bs4_module = types.ModuleType("bs4")
+    bs4_module.BeautifulSoup = object
+    sys.modules.setdefault("bs4", bs4_module)
+    feedparser_module = types.ModuleType("feedparser")
+    feedparser_module.parse = lambda *a, **k: types.SimpleNamespace(entries=[])
+    sys.modules.setdefault("feedparser", feedparser_module)
+    numpy_module = types.ModuleType("numpy")
+    sys.modules.setdefault("numpy", numpy_module)
+    substrate_module = types.ModuleType("substrateinterface")
+    substrate_module.SubstrateInterface = object
+    sys.modules.setdefault("substrateinterface", substrate_module)
+
+    import src.main as main
+
     monkeypatch.setattr(main, "collect_recent_messages", lambda: [])
     monkeypatch.setattr(main, "analyse_messages", lambda msgs: {})
     monkeypatch.setattr(main, "fetch_and_summarise_news", lambda: {})
@@ -11,7 +28,7 @@ def test_main_records_final_status(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
     monkeypatch.setattr(main, "build_context", lambda *args: {})
     monkeypatch.setattr(main, "forecast_outcomes", lambda context: {})
-    monkeypatch.setattr(main, "generate_completion", lambda **kwargs: "Proposal")
+    monkeypatch.setattr(main.proposal_generator, "draft", lambda context: "Proposal")
     monkeypatch.setattr(main, "broadcast_proposal", lambda text: None)
     monkeypatch.setattr(main, "submit_proposal", lambda text: "0xsub")
     monkeypatch.setattr(main, "record_proposal", lambda text, sid: None)

--- a/tests/test_proposal_generator.py
+++ b/tests/test_proposal_generator.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from src.agents import proposal_generator
+
+
+def test_draft_uses_build_prompt_and_ollama():
+    context = {"foo": "bar"}
+    expected_prompt = proposal_generator.build_prompt(context)
+
+    with patch(
+        "src.agents.proposal_generator.ollama_api.generate_completion",
+        return_value="result",
+    ) as mock_gen:
+        result = proposal_generator.draft(context)
+
+    mock_gen.assert_called_once_with(
+        prompt=expected_prompt,
+        system="You are Polkadot-Gov-Agent v1.",
+        model="gemma3:4b",
+        temperature=0.3,
+        max_tokens=2048,
+    )
+    assert result == "result"

--- a/tests/test_proposal_submission.py
+++ b/tests/test_proposal_submission.py
@@ -68,7 +68,7 @@ def test_main_submits(monkeypatch, capsys):
     monkeypatch.setattr(main, "get_recent_blocks_cached", lambda: [])
     monkeypatch.setattr(main, "summarise_blocks", lambda blocks: {})
     monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
-    monkeypatch.setattr(main, "generate_completion", lambda **kwargs: "proposal text")
+    monkeypatch.setattr(main.proposal_generator, "draft", lambda context: "proposal text")
     monkeypatch.setattr(main, "record_context", lambda ctx: None)
 
     def fake_submit(text, credentials=None):


### PR DESCRIPTION
## Summary
- add `proposal_generator` agent wrapping LLM completion
- use proposal generator agent in main pipeline
- cover proposal generator with unit test

## Testing
- `pytest tests/test_proposal_generator.py tests/test_main_execution.py tests/test_proposal_submission.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894deff4fc48322bf01317ccc7e067e