### PR TITLE
Add proposal search and integrate knowledge base snippets

### DIFF
--- a/src/agents/context_generator.py
+++ b/src/agents/context_generator.py
@@ -11,6 +11,7 @@ def build_context(
     news: Dict[str, Any],
     chain_kpis: Dict[str, Any],
     gov_kpis: Dict[str, Any],
+    kb_snippets: list[str] | None = None,
 ) -> Dict[str, Any]:
     """Consolidate disparate inputs into a single context dictionary."""
     return {
@@ -19,4 +20,5 @@ def build_context(
         "news": news,
         "chain_kpis": chain_kpis,
         "governance_kpis": gov_kpis,
+        "kb_snippets": kb_snippets or [],
     }

--- a/src/data_processing/proposal_store.py
+++ b/src/data_processing/proposal_store.py
@@ -97,3 +97,22 @@ def load_execution_results():
         return pd.read_excel(XLSX_PATH, sheet_name="ExecutionResults")
     except Exception:
         return pd.DataFrame()
+
+
+def search_proposals(query: str, limit: int) -> list[str]:
+    """Return up to ``limit`` proposal texts containing ``query``.
+
+    Performs a case-insensitive search over the stored proposals using
+    pandas' string matching and returns a list of matching snippets.
+    """
+    import pandas as pd
+
+    if not query:
+        return []
+
+    df = load_proposals()
+    if df.empty or "proposal_text" not in df.columns:
+        return []
+
+    mask = df["proposal_text"].astype(str).str.contains(query, case=False, na=False)
+    return df.loc[mask, "proposal_text"].head(limit).tolist()

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ from data_processing.proposal_store import (
     record_proposal,
     record_execution_result,
     record_context,
+    search_proposals,
 )
 
 
@@ -77,8 +78,13 @@ def main() -> None:
     update_referenda(max_new=500)  # refresh knowledge-base quickly
     gov_kpis = get_governance_insights(as_narrative=True)
 
+    # Retrieve relevant knowledge-base snippets from prior proposals
+    keywords = gov_kpis.get("top_keywords", []) if isinstance(gov_kpis, dict) else []
+    query = keywords[0] if keywords else ""
+    kb_snippets = search_proposals(query, limit=5)
+
     # Bundle context via agent
-    context = build_context(sentiment, news, chain_kpis, gov_kpis)
+    context = build_context(sentiment, news, chain_kpis, gov_kpis, kb_snippets)
     forecast = forecast_outcomes(context)
     context["forecast"] = forecast
     timestamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -1,4 +1,5 @@
 import json
+import json
 from src.agents.context_generator import build_context
 from src.data_processing import proposal_store
 from src.utils import validators as v
@@ -30,14 +31,17 @@ def _dummy_components():
 
 def test_build_context_structure():
     sentiment, news, chain, gov = _dummy_components()
-    ctx = build_context(sentiment, news, chain, gov)
+    snippets = ["previous proposal"]
+    ctx = build_context(sentiment, news, chain, gov, snippets)
     assert set(ctx.keys()) == {
         "timestamp_utc",
         "sentiment",
         "news",
         "chain_kpis",
         "governance_kpis",
+        "kb_snippets",
     }
+    assert ctx["kb_snippets"] == snippets
     assert v.validate_sentiment(ctx["sentiment"])
     assert v.validate_news(ctx["news"])
     assert v.validate_chain_kpis(ctx["chain_kpis"])
@@ -46,7 +50,8 @@ def test_build_context_structure():
 
 def test_record_context_persist(tmp_path, monkeypatch):
     sentiment, news, chain, gov = _dummy_components()
-    ctx = build_context(sentiment, news, chain, gov)
+    snippets = ["snippet"]
+    ctx = build_context(sentiment, news, chain, gov, snippets)
     monkeypatch.setattr(proposal_store, "XLSX_PATH", tmp_path / "gov.xlsx")
     proposal_store.record_context(ctx)
     from openpyxl import load_workbook
@@ -61,3 +66,4 @@ def test_record_context_persist(tmp_path, monkeypatch):
     assert stored["news"] == news
     assert stored["chain_kpis"] == chain
     assert stored["governance_kpis"] == gov
+    assert stored["kb_snippets"] == snippets

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,1 +1,16 @@
  
+import pandas as pd
+from src.data_processing import proposal_store
+
+
+def test_search_proposals_returns_matches(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {"proposal_text": "Improve governance transparency"},
+            {"proposal_text": "Another proposal about fees"},
+        ]
+    )
+    monkeypatch.setattr(proposal_store, "load_proposals", lambda: df)
+
+    results = proposal_store.search_proposals("governance", limit=5)
+    assert results == ["Improve governance transparency"]

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -26,7 +26,14 @@ def test_main_records_final_status(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "summarise_blocks", lambda blocks: {})
     monkeypatch.setattr(main, "update_referenda", lambda max_new: None)
     monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
-    monkeypatch.setattr(main, "build_context", lambda *args: {})
+    captured_kb = {}
+
+    def fake_build_context(sentiment, news, chain, gov, kb_snippets=None):
+        captured_kb["snippets"] = kb_snippets
+        return {}
+
+    monkeypatch.setattr(main, "build_context", fake_build_context)
+    monkeypatch.setattr(main, "search_proposals", lambda q, limit: ["snippet1"])
     monkeypatch.setattr(main, "forecast_outcomes", lambda context: {})
     monkeypatch.setattr(main.proposal_generator, "draft", lambda context: "Proposal")
     monkeypatch.setattr(main, "broadcast_proposal", lambda text: None)
@@ -54,3 +61,4 @@ def test_main_records_final_status(monkeypatch, tmp_path):
         "outcome": "Approved",
         "submission_id": "0xsub",
     }
+    assert captured_kb["snippets"] == ["snippet1"]


### PR DESCRIPTION
## Summary
- add `search_proposals` to query past proposals with pandas string matching
- extend context generator with optional `kb_snippets`
- fetch and pass KB snippets in `main` workflow
- add tests for proposal search and snippet integration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894e3d1579083228e30e45e734232a2