### PR TITLE
Remove debug proposal snippet search and update test

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,6 @@ from data_processing.proposal_store import (
     record_proposal,
     record_execution_result,
     record_context,
-    search_proposals,
 )
 
 
@@ -79,9 +78,10 @@ def main() -> None:
     gov_kpis = get_governance_insights(as_narrative=True)
 
     # Retrieve relevant knowledge-base snippets from prior proposals
-    keywords = gov_kpis.get("top_keywords", []) if isinstance(gov_kpis, dict) else []
-    query = keywords[0] if keywords else ""
-    kb_snippets = search_proposals(query, limit=5)
+    # keywords = gov_kpis.get("top_keywords", []) if isinstance(gov_kpis, dict) else []
+    # query = keywords[0] if keywords else ""
+    # kb_snippets = search_proposals(query, limit=5)
+    kb_snippets: list[str] = []
 
     # Bundle context via agent
     context = build_context(sentiment, news, chain_kpis, gov_kpis, kb_snippets)

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -33,7 +33,6 @@ def test_main_records_final_status(monkeypatch, tmp_path):
         return {}
 
     monkeypatch.setattr(main, "build_context", fake_build_context)
-    monkeypatch.setattr(main, "search_proposals", lambda q, limit: ["snippet1"])
     monkeypatch.setattr(main, "forecast_outcomes", lambda context: {})
     monkeypatch.setattr(main.proposal_generator, "draft", lambda context: "Proposal")
     monkeypatch.setattr(main, "broadcast_proposal", lambda text: None)
@@ -61,4 +60,4 @@ def test_main_records_final_status(monkeypatch, tmp_path):
         "outcome": "Approved",
         "submission_id": "0xsub",
     }
-    assert captured_kb["snippets"] == ["snippet1"]
+    assert captured_kb["snippets"] == []


### PR DESCRIPTION
## Summary
- stop searching prior proposals during main pipeline (debug snippet code removed)
- keep news output from `fetch_and_summarise_news`
- adjust `test_main_execution` for no knowledge-base snippets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894eab5a7a483228fdb523d7206ba04