### PR TITLE
Refactor sentiment and prediction functions into agent modules

### DIFF
--- a/src/agents/outcome_forecaster.py
+++ b/src/agents/outcome_forecaster.py
@@ -1,0 +1,42 @@
+"""Outcome forecasting agent."""
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+from src.data_processing.data_loader import load_governance_data
+
+
+def forecast_outcomes(context: Dict) -> Dict[str, float]:
+    """Return naive forecasts for upcoming referendum outcomes."""
+    try:
+        df = load_governance_data(sheet_name="Referenda")
+    except Exception:
+        df = pd.DataFrame()
+
+    approval_prob = 0.5
+    turnout_estimate = 0.0
+
+    try:
+        if not df.empty:
+            if "Status" in df.columns and len(df):
+                approved = df["Status"].astype(str).str.lower().eq("executed").sum()
+                approval_prob = approved / len(df)
+            if "Voted_percentage" in df.columns:
+                turnout_estimate = df["Voted_percentage"].astype(float).mean() / 100.0
+            elif {"Participants", "Eligible_DOT"}.issubset(df.columns):
+                turnout_estimate = (
+                    (df["Participants"].astype(float) / df["Eligible_DOT"].replace(0, pd.NA))
+                    .fillna(0)
+                    .mean()
+                )
+    except Exception:
+        pass
+
+    approval_prob = float(max(0.0, min(1.0, approval_prob)))
+    turnout_estimate = float(max(0.0, min(1.0, turnout_estimate)))
+    return {
+        "approval_prob": approval_prob,
+        "turnout_estimate": turnout_estimate,
+    }

--- a/src/agents/sentiment_analyser.py
+++ b/src/agents/sentiment_analyser.py
@@ -1,0 +1,70 @@
+"""Sentiment analysis agent providing message summaries."""
+from __future__ import annotations
+
+import json
+import re
+import textwrap
+from typing import Iterable, Dict, Any
+
+from llm.ollama_api import generate_completion
+
+POS = re.compile(r"\b(great|good|awesome|up|bull|positive|love)\b", re.I)
+NEG = re.compile(r"\b(bad|terrible|down|bear|negative|hate|risk)\b", re.I)
+
+
+def _extract_json(text: str) -> dict | None:
+    """Pull the first JSON object found in the text."""
+    match = re.search(r"\{.*\}", text, re.S)
+    if not match:
+        return None
+    try:
+        return json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+
+
+def simple_polarity(text: str) -> float:
+    """Very naive fallback sentiment score."""
+    pos = len(POS.findall(text))
+    neg = len(NEG.findall(text))
+    total = pos + neg or 1
+    return (pos - neg) / total
+
+
+SYSTEM_PROMPT = textwrap.dedent(
+    """
+    You are a concise blockchain community-analysis assistant.
+    Given raw Discord / Telegram / X messages, return JSON with:
+      sentiment_score : float  # –1 (very negative) … 1 (very positive)
+      summary         : str    # 2‑3 sentence plain‑English recap
+      key_topics      : list[str]  # max 5 bullet keywords / phrases
+    Only output valid minified JSON – no commentary, no markdown.
+    """
+).strip()
+
+
+def analyse_messages(messages: Iterable[str]) -> Dict[str, Any]:
+    """Run LLM sentiment analysis over ``messages``."""
+    raw_text = "\n".join(messages).strip()[:8000]
+
+    try:
+        response = generate_completion(
+            prompt=raw_text,
+            system=SYSTEM_PROMPT,
+            temperature=0.1,
+            max_tokens=256,
+            model="gemma3:4b",
+        )
+        result = _extract_json(response)
+        if result is None:
+            raise ValueError("No JSON returned")
+        for k in ("sentiment_score", "summary", "key_topics"):
+            result.setdefault(k, "")
+        return result
+    except Exception:
+        score = simple_polarity(raw_text)
+        return {
+            "sentiment_score": score,
+            "summary": "LLM fallback – basic polarity calculated.",
+            "key_topics": [],
+        }

--- a/src/analysis/prediction_analysis.py
+++ b/src/analysis/prediction_analysis.py
@@ -1,60 +1,13 @@
-import pandas as pd
+"""Compatibility wrapper for prediction analysis functions."""
+from __future__ import annotations
+
 from typing import Dict
 
-from src.data_processing.data_loader import load_governance_data
+from agents.outcome_forecaster import forecast_outcomes as _forecast_outcomes
+
+__all__ = ["forecast_outcomes"]
 
 
 def forecast_outcomes(context: Dict) -> Dict[str, float]:
-    """Return naive forecasts for upcoming referendum outcomes.
-
-    The function inspects historical referendum data stored in the
-    ``PKD Governance Data.xlsx`` workbook and computes two simple metrics:
-
-    ``approval_prob``
-        Fraction of past referenda that executed successfully.
-    ``turnout_estimate``
-        Average voter turnout (participants / eligible) across historical
-        referenda.
-
-    Parameters
-    ----------
-    context: dict
-        Unused currently but kept for future model features.
-
-    Returns
-    -------
-    dict
-        Dictionary with ``approval_prob`` and ``turnout_estimate`` keys.
-    """
-    try:
-        df = load_governance_data(sheet_name="Referenda")
-    except Exception:
-        df = pd.DataFrame()
-
-    approval_prob = 0.5
-    turnout_estimate = 0.0
-
-    try:
-        if not df.empty:
-            # Approval probability: share of executed referenda
-            if "Status" in df.columns and len(df):
-                approved = df["Status"].astype(str).str.lower().eq("executed").sum()
-                approval_prob = approved / len(df)
-            # Turnout: either provided percentage or compute from counts
-            if "Voted_percentage" in df.columns:
-                turnout_estimate = df["Voted_percentage"].astype(float).mean() / 100.0
-            elif {"Participants", "Eligible_DOT"}.issubset(df.columns):
-                turnout_estimate = (
-                    (df["Participants"].astype(float) / df["Eligible_DOT"].replace(0, pd.NA))
-                    .fillna(0)
-                    .mean()
-                )
-    except Exception:
-        pass
-
-    approval_prob = float(max(0.0, min(1.0, approval_prob)))
-    turnout_estimate = float(max(0.0, min(1.0, turnout_estimate)))
-    return {
-        "approval_prob": approval_prob,
-        "turnout_estimate": turnout_estimate,
-    }
+    """Delegate to :func:`agents.outcome_forecaster.forecast_outcomes`."""
+    return _forecast_outcomes(context)

--- a/src/analysis/sentiment_analysis.py
+++ b/src/analysis/sentiment_analysis.py
@@ -1,114 +1,17 @@
-"""
-sentiment_analysis.py
----------------------
-Summarise community chatter and return
-• overall polarity score  (-1 … 1)
-• brief natural‑language summary
-• key topics or concerns
-"""
-
+"""Compatibility wrapper for sentiment analysis functions."""
 from __future__ import annotations
-import json
+
 from typing import Iterable, Dict, Any
-import textwrap
-from src.llm.ollama_api import generate_completion
 
-# ────────────────────────────────────────────────────────────────────────────
-# Basic rule‑based polarity helper (backup if LLM unavailable)
-# ────────────────────────────────────────────────────────────────────────────
-import re
+from agents.sentiment_analyser import (
+    analyse_messages as _analyse_messages,
+    _extract_json,
+    simple_polarity,
+)
 
-POS = re.compile(r"\b(great|good|awesome|up|bull|positive|love)\b", re.I)
-NEG = re.compile(r"\b(bad|terrible|down|bear|negative|hate|risk)\b", re.I)
-
-
-def _extract_json(text: str) -> dict | None:
-    """
-    Pull the first JSON object found in the text.
-    Handles models that wrap with ```json ... ``` or extra prose.
-    """
-    match = re.search(r'\{.*\}', text, re.S)
-    if not match:
-        return None
-    try:
-        return json.loads(match.group(0))
-    except json.JSONDecodeError:
-        return None
-
-
-def simple_polarity(text: str) -> float:
-    """Very naive fallback sentiment score."""
-    pos = len(POS.findall(text))
-    neg = len(NEG.findall(text))
-    total = pos + neg or 1
-    return (pos - neg) / total
-
-
-# ────────────────────────────────────────────────────────────────────────────
-# Main high‑level function
-# ────────────────────────────────────────────────────────────────────────────
-SYSTEM_PROMPT = textwrap.dedent(
-    """
-    You are a concise blockchain community‑analysis assistant.
-    Given raw Discord / Telegram / X messages, return JSON with:
-      sentiment_score : float  # –1 (very negative) … 1 (very positive)
-      summary         : str    # 2‑3 sentence plain‑English recap
-      key_topics      : list[str]  # max 5 bullet keywords / phrases
-    Only output valid minified JSON – no commentary, no markdown.
-    """
-).strip()
+__all__ = ["analyse_messages", "_extract_json", "simple_polarity"]
 
 
 def analyse_messages(messages: Iterable[str]) -> Dict[str, Any]:
-    """
-    Run Deepseek on concatenated messages to get structured sentiment.
-
-    Parameters
-    ----------
-    messages : Iterable[str]
-        Raw text snippets (one per message).
-
-    Returns
-    -------
-    dict
-        { "sentiment_score": float, "summary": str, "key_topics": [...] }
-    """
-    raw_text = "\n".join(messages).strip()[:8000]  # avoid exceeding context
-
-    try:
-        response = generate_completion(
-            prompt=raw_text,
-            system=SYSTEM_PROMPT,
-            temperature=0.1,
-            max_tokens=256,
-            model="gemma3:4b",
-        )
-        # print("RAW:", response[:500], "...\n")
-        result = _extract_json(response)
-        if result is None:
-            raise ValueError("No JSON returned")
-
-        # sanity‑check required keys
-        for k in ("sentiment_score", "summary", "key_topics"):
-            result.setdefault(k, "")
-        return result
-    except Exception:
-        # fallback tiny rule‑based score
-        score = simple_polarity(raw_text)
-        return {
-            "sentiment_score": score,
-            "summary": "LLM fallback – basic polarity calculated.",
-            "key_topics": [],
-        }
-
-
-# ────────────────────────────────────────────────────────────────────────────
-# Stand‑alone test
-# ────────────────────────────────────────────────────────────────────────────
-if __name__ == "__main__":
-    dummy_msgs = [
-        "Polkadot is pumping hard today 🔥🔥",
-        "The new OpenGov referendum looks risky to me.",
-        "Love the dev updates from parity!",
-    ]
-    print(analyse_messages(dummy_msgs))
+    """Delegate to :func:`agents.sentiment_analyser.analyse_messages`."""
+    return _analyse_messages(messages)

--- a/src/main.py
+++ b/src/main.py
@@ -12,14 +12,14 @@ from __future__ import annotations
 import json, pathlib, datetime as dt, os
 from agents.data_collector import DataCollector
 from data_processing.social_media_scraper import collect_recent_messages
-from analysis.sentiment_analysis import analyse_messages
+from agents.sentiment_analyser import analyse_messages
 from data_processing.news_fetcher import fetch_and_summarise_news
 from data_processing.referenda_updater import update_referenda
 # from data_processing.blockchain_data_fetcher import fetch_recent_blocks
 from data_processing.blockchain_cache import get_recent_blocks_cached
 from analysis.blockchain_metrics import summarise_blocks
 from analysis.governance_analysis import get_governance_insights
-from analysis.prediction_analysis import forecast_outcomes
+from agents.outcome_forecaster import forecast_outcomes
 from agents import proposal_generator
 from agents.proposal_submission import submit_proposal
 from agents.context_generator import build_context

--- a/tests/test_prediction_analysis.py
+++ b/tests/test_prediction_analysis.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from src.analysis.prediction_analysis import forecast_outcomes
+from src.agents.outcome_forecaster import forecast_outcomes
 from src.data_processing import data_loader
 
 


### PR DESCRIPTION
## Summary
- add `sentiment_analyser` and `outcome_forecaster` agents
- keep wrappers in `analysis` modules for compatibility
- update imports in main module and tests to use new agent interfaces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ef7102d0832289a6030cf30b3673