### PR TITLE
Integrate proposal history into context generation

### DIFF
--- a/src/agents/context_generator.py
+++ b/src/agents/context_generator.py
@@ -1,9 +1,30 @@
 """Context generation utilities."""
 from __future__ import annotations
 
-from typing import Dict, Any
+from typing import Dict, Any, Iterable
 
 from utils.helpers import utc_now_iso
+
+
+def _dedup(snippets: Iterable[str]) -> list[str]:
+    """Return snippets with duplicates removed while preserving order."""
+    seen = set()
+    deduped: list[str] = []
+    for s in snippets:
+        s = s.strip()
+        if s and s not in seen:
+            seen.add(s)
+            deduped.append(s)
+    return deduped
+
+
+def _summarise(snippets: list[str]) -> str:
+    """Naively summarise snippets by concatenation.
+
+    A lightweight fallback is used instead of an LLM so tests remain
+    deterministic.  Callers can post-process this summary further if desired.
+    """
+    return " ".join(snippets)[:500]
 
 
 def build_context(
@@ -12,13 +33,30 @@ def build_context(
     chain_kpis: Dict[str, Any],
     gov_kpis: Dict[str, Any],
     kb_snippets: list[str] | None = None,
+    *,
+    dedup_snippets: bool = True,
+    summarise_snippets: bool = False,
 ) -> Dict[str, Any]:
-    """Consolidate disparate inputs into a single context dictionary."""
+    """Consolidate disparate inputs into a single context dictionary.
+
+    Parameters
+    ----------
+    dedup_snippets:
+        Remove duplicate snippets before inclusion.
+    summarise_snippets:
+        If True, a ``kb_summary`` field containing a simple concatenation of
+        snippets is added.
+    """
+    snippets = kb_snippets or []
+    if dedup_snippets:
+        snippets = _dedup(snippets)
+    summary = _summarise(snippets) if summarise_snippets and snippets else ""
     return {
         "timestamp_utc": utc_now_iso(),
         "sentiment": sentiment,
         "news": news,
         "chain_kpis": chain_kpis,
         "governance_kpis": gov_kpis,
-        "kb_snippets": kb_snippets or [],
+        "kb_snippets": snippets,
+        "kb_summary": summary,
     }

--- a/src/main.py
+++ b/src/main.py
@@ -31,6 +31,7 @@ from data_processing.proposal_store import (
     record_proposal,
     record_execution_result,
     record_context,
+    search_proposals,
 )
 
 
@@ -78,10 +79,10 @@ def main() -> None:
     gov_kpis = get_governance_insights(as_narrative=True)
 
     # Retrieve relevant knowledge-base snippets from prior proposals
-    # keywords = gov_kpis.get("top_keywords", []) if isinstance(gov_kpis, dict) else []
-    # query = keywords[0] if keywords else ""
-    # kb_snippets = search_proposals(query, limit=5)
+    keywords = gov_kpis.get("top_keywords", []) if isinstance(gov_kpis, dict) else []
     kb_snippets: list[str] = []
+    for kw in keywords[:3]:  # limit to top 3 keywords
+        kb_snippets.extend(search_proposals(kw, limit=3))
 
     # Bundle context via agent
     context = build_context(sentiment, news, chain_kpis, gov_kpis, kb_snippets)


### PR DESCRIPTION
## Summary
- pull prior proposal snippets via `search_proposals` based on governance KPIs
- allow context generator to deduplicate and summarise knowledge-base snippets
- add tests for proposal search and context assembly

## Testing
- `pytest tests/test_context_generation.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f751daac8322bd2b1d87f6d7ed77