### PR TITLE
Integrate on-chain referendum flow

### DIFF
--- a/src/execution/governor_interface.py
+++ b/src/execution/governor_interface.py
@@ -8,7 +8,7 @@ chain for the final outcome of a referendum.
 from __future__ import annotations
 
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional, Union
 
 
 def connect(node_url: str):
@@ -31,6 +31,54 @@ def _create_keypair(private_key: str):
     return Keypair.create_from_private_key(private_key)
 
 
+def _tracks(substrate: Any) -> Dict[int, Dict[str, Any]]:
+    """Return mapping of track id -> info."""
+    tracks = substrate.get_constant("Referenda", "Tracks")
+    # Chain constants may be list of tuples; normalise to dict
+    if isinstance(tracks, dict):
+        return tracks
+    result: Dict[int, Dict[str, Any]] = {}
+    if isinstance(tracks, Iterable):
+        for item in tracks:
+            if isinstance(item, (tuple, list)) and len(item) == 2:
+                result[int(item[0])] = item[1]
+    return result
+
+
+def resolve_track(substrate: Any, track: Union[str, int]) -> int:
+    """Return numeric track id for ``track`` which may be name or id."""
+    if isinstance(track, int):
+        return track
+    tracks = _tracks(substrate)
+    for tid, info in tracks.items():
+        name = info.get("name") or info.get("Name") or info.get("track")
+        if name == track:
+            return int(tid)
+    raise ValueError(f"Unknown track: {track}")
+
+
+def required_deposit(substrate: Any, track_id: int) -> int:
+    """Return the decision deposit required for ``track_id``."""
+    info = _tracks(substrate).get(track_id, {})
+    deposit = info.get("decision_deposit") or info.get("decisionDeposit")
+    if deposit is None:
+        return 0
+    try:
+        return int(deposit)
+    except Exception:
+        return 0
+
+
+def _extract_event(receipt: Any, module: str, event: str) -> Optional[Any]:
+    events = getattr(receipt, "triggered_events", []) or []
+    for e in events:
+        mod = getattr(e, "event_module", getattr(getattr(e, "event", {}), "module", ""))
+        name = getattr(e, "event_name", getattr(getattr(e, "event", {}), "event", ""))
+        if mod == module and name == event:
+            return e
+    return None
+
+
 def submit_preimage(node_url: str, private_key: str, preimage: bytes) -> Dict[str, Any]:
     """Submit a preimage to the chain and return receipt details."""
     substrate = connect(node_url)
@@ -42,27 +90,57 @@ def submit_preimage(node_url: str, private_key: str, preimage: bytes) -> Dict[st
     )
     extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
     receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
-    return parse_receipt(receipt)
+    result = parse_receipt(receipt)
+    event = _extract_event(receipt, "Preimage", "Noted")
+    if event is not None:
+        params = getattr(event, "params", [])
+        if params:
+            hash_val = params[0].get("value") if isinstance(params[0], dict) else getattr(params[0], "value", None)
+            result["preimage_hash"] = hash_val
+    return result
 
 
 def submit_proposal(
-    node_url: str, private_key: str, preimage_hash: str, track_id: int, value: int
+    node_url: str,
+    private_key: str,
+    preimage_hash: str,
+    track: Union[str, int],
+    value: Optional[int] = None,
 ) -> Dict[str, Any]:
-    """Submit a referendum proposal referencing an existing preimage."""
+    """Submit a referendum proposal referencing an existing preimage.
+
+    Parameters
+    ----------
+    node_url, private_key, preimage_hash: see :func:`submit_preimage`.
+    track: Union[str, int]
+        Track identifier or human-readable name.
+    value: Optional[int]
+        Deposit to attach. If omitted the chain's required decision deposit
+        for the given track is used.
+    """
     substrate = connect(node_url)
     keypair = _create_keypair(private_key)
+    track_id = resolve_track(substrate, track)
+    deposit = value if value is not None else required_deposit(substrate, track_id)
     call = substrate.compose_call(
         call_module="Referenda",
         call_function="submit",
         call_params={
             "proposal": preimage_hash,
             "track": track_id,
-            "value": value,
+            "value": deposit,
         },
     )
     extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
     receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
-    return parse_receipt(receipt)
+    result = parse_receipt(receipt)
+    event = _extract_event(receipt, "Referenda", "Submitted")
+    if event is not None:
+        params = getattr(event, "params", [])
+        if params:
+            idx = params[0].get("value") if isinstance(params[0], dict) else getattr(params[0], "value", None)
+            result["referendum_index"] = idx
+    return result
 
 
 def query_proposal_status(node_url: str, referendum_index: int) -> Optional[str]:

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -36,7 +36,20 @@ def test_main_records_final_status(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "forecast_outcomes", lambda context: {})
     monkeypatch.setattr(main.proposal_generator, "draft", lambda context: "Proposal")
     monkeypatch.setattr(main, "broadcast_proposal", lambda text: None)
-    monkeypatch.setattr(main, "submit_proposal", lambda text: "0xsub")
+    monkeypatch.setattr(
+        main,
+        "submit_preimage",
+        lambda url, pk, data: {"preimage_hash": "0xhash", "extrinsic_hash": "0xpre"},
+    )
+    monkeypatch.setattr(
+        main,
+        "submit_proposal",
+        lambda url, pk, hash_, track: {
+            "extrinsic_hash": "0xsub",
+            "referendum_index": 1,
+            "is_success": True,
+        },
+    )
     monkeypatch.setattr(main, "record_proposal", lambda text, sid: None)
     monkeypatch.setattr(main, "record_context", lambda context: None)
     monkeypatch.setattr(main, "await_execution", lambda node_url, idx, sid: ("0xblock", "Approved"))
@@ -50,7 +63,8 @@ def test_main_records_final_status(monkeypatch, tmp_path):
 
     monkeypatch.setattr(main, "OUT_DIR", tmp_path)
     monkeypatch.setenv("SUBSTRATE_NODE_URL", "ws://node")
-    monkeypatch.setenv("REFERENDUM_INDEX", "1")
+    monkeypatch.setenv("SUBSTRATE_PRIVATE_KEY", "priv")
+    monkeypatch.setenv("GOVERNANCE_TRACK", "root")
 
     main.main()
 

--- a/tests/test_proposal_submission.py
+++ b/tests/test_proposal_submission.py
@@ -71,10 +71,21 @@ def test_main_submits(monkeypatch, capsys):
     monkeypatch.setattr(main.proposal_generator, "draft", lambda context: "proposal text")
     monkeypatch.setattr(main, "record_context", lambda ctx: None)
 
-    def fake_submit(text, credentials=None):
-        assert text == "proposal text"
-        return "abc123"
+    monkeypatch.setattr(
+        main,
+        "submit_preimage",
+        lambda url, pk, data: {"preimage_hash": "0xhash", "extrinsic_hash": "0xpre"},
+    )
+
+    def fake_submit(url, pk, hash_, track):
+        assert hash_ == "0xhash"
+        return {"extrinsic_hash": "abc123", "referendum_index": 7, "is_success": True}
+
     monkeypatch.setattr(main, "submit_proposal", fake_submit)
+
+    monkeypatch.setenv("SUBSTRATE_NODE_URL", "ws://node")
+    monkeypatch.setenv("SUBSTRATE_PRIVATE_KEY", "priv")
+    monkeypatch.setenv("GOVERNANCE_TRACK", "root")
 
     main.main()
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add track resolution, deposit calculation and event parsing to OpenGov helper
- submit preimages and track referendum indices in main pipeline
- test governor interface with successful and failing on-chain submissions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895bc62a278832285f8bc3b386e5a1d