### PR TITLE
feat: enrich context with semantic retrieval

### DIFF
--- a/src/agents/context_generator.py
+++ b/src/agents/context_generator.py
@@ -1,9 +1,12 @@
 """Context generation utilities."""
 from __future__ import annotations
 
-from typing import Dict, Any, Iterable
+from math import sqrt
+from typing import Any, Dict, Iterable, List, Tuple
 
 from utils.helpers import utc_now_iso
+from data_processing import proposal_store
+from llm import ollama_api
 
 
 def _dedup(snippets: Iterable[str]) -> list[str]:
@@ -18,13 +21,64 @@ def _dedup(snippets: Iterable[str]) -> list[str]:
     return deduped
 
 
-def _summarise(snippets: list[str]) -> str:
-    """Naively summarise snippets by concatenation.
+def _cosine_similarity(a: List[float], b: List[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    if not a or not b:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = sqrt(sum(x * x for x in a))
+    norm_b = sqrt(sum(y * y for y in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
 
-    A lightweight fallback is used instead of an LLM so tests remain
-    deterministic.  Callers can post-process this summary further if desired.
-    """
-    return " ".join(snippets)[:500]
+
+def _fetch_semantic_snippets(query: str, limit: int = 5) -> list[str]:
+    """Retrieve snippets most similar to ``query`` using embeddings."""
+    if not query:
+        return []
+
+    proposals = proposal_store.load_proposals()
+    contexts = proposal_store.load_contexts()
+
+    candidates: list[str] = []
+    if not proposals.empty and "proposal_text" in proposals.columns:
+        candidates.extend(
+            proposals["proposal_text"].dropna().astype(str).tolist()
+        )
+    if not contexts.empty and "context_json" in contexts.columns:
+        candidates.extend(
+            contexts["context_json"].dropna().astype(str).tolist()
+        )
+
+    if not candidates:
+        return []
+
+    try:
+        query_vec = ollama_api.embed_text(query)
+    except Exception:
+        return []
+
+    scored: List[Tuple[float, str]] = []
+    for text in candidates:
+        try:
+            vec = ollama_api.embed_text(text)
+        except Exception:
+            continue
+        score = _cosine_similarity(query_vec, vec)
+        scored.append((score, text))
+
+    scored.sort(key=lambda t: t[0], reverse=True)
+    return [text for _, text in scored[:limit]]
+
+
+def _summarise(snippets: list[str]) -> str:
+    """Summarise ``snippets`` using the LLM with a naive fallback."""
+    prompt = "Summarise the following snippets:\n" + "\n".join(snippets)
+    try:
+        return ollama_api.generate_completion(prompt)
+    except Exception:
+        return " ".join(snippets)[:500]
 
 
 def build_context(
@@ -33,25 +87,22 @@ def build_context(
     chain_kpis: Dict[str, Any],
     gov_kpis: Dict[str, Any],
     kb_snippets: list[str] | None = None,
+    kb_query: str | None = None,
     *,
     dedup_snippets: bool = True,
     summarise_snippets: bool = False,
 ) -> Dict[str, Any]:
-    """Consolidate disparate inputs into a single context dictionary.
+    """Consolidate disparate inputs into a single context dictionary."""
 
-    Parameters
-    ----------
-    dedup_snippets:
-        Remove duplicate snippets before inclusion.
-    summarise_snippets:
-        If True, a ``kb_summary`` field containing a simple concatenation of
-        snippets is added.
-    """
     snippets = kb_snippets or []
+    if not snippets and kb_query:
+        snippets = _fetch_semantic_snippets(kb_query)
+
     if dedup_snippets:
         snippets = _dedup(snippets)
     summary = _summarise(snippets) if summarise_snippets and snippets else ""
-    return {
+
+    context = {
         "timestamp_utc": utc_now_iso(),
         "sentiment": sentiment,
         "news": news,
@@ -60,3 +111,7 @@ def build_context(
         "kb_snippets": snippets,
         "kb_summary": summary,
     }
+
+    # Persist for audit trail
+    proposal_store.record_context(context)
+    return context

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,6 +1,6 @@
  
 import pandas as pd
-from src.data_processing import proposal_store
+from data_processing import proposal_store
 
 
 def test_search_proposals_returns_matches(monkeypatch):

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -28,8 +28,8 @@ def test_main_records_final_status(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
     captured_kb = {}
 
-    def fake_build_context(sentiment, news, chain, gov, kb_snippets=None):
-        captured_kb["snippets"] = kb_snippets
+    def fake_build_context(sentiment, news, chain, gov, kb_snippets=None, kb_query=None, **_):
+        captured_kb["query"] = kb_query
         return {}
 
     monkeypatch.setattr(main, "build_context", fake_build_context)
@@ -51,7 +51,6 @@ def test_main_records_final_status(monkeypatch, tmp_path):
         },
     )
     monkeypatch.setattr(main, "record_proposal", lambda text, sid: None)
-    monkeypatch.setattr(main, "record_context", lambda context: None)
     monkeypatch.setattr(main, "await_execution", lambda node_url, idx, sid: ("0xblock", "Approved"))
 
     recorded = {}
@@ -74,4 +73,4 @@ def test_main_records_final_status(monkeypatch, tmp_path):
         "outcome": "Approved",
         "submission_id": "0xsub",
     }
-    assert captured_kb["snippets"] == []
+    assert captured_kb["query"] == ""

--- a/tests/test_proposal_submission.py
+++ b/tests/test_proposal_submission.py
@@ -69,7 +69,8 @@ def test_main_submits(monkeypatch, capsys):
     monkeypatch.setattr(main, "summarise_blocks", lambda blocks: {})
     monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
     monkeypatch.setattr(main.proposal_generator, "draft", lambda context: "proposal text")
-    monkeypatch.setattr(main, "record_context", lambda ctx: None)
+    monkeypatch.setattr(main, "build_context", lambda *a, **k: {})
+    monkeypatch.setattr(main, "forecast_outcomes", lambda ctx: {})
 
     monkeypatch.setattr(
         main,


### PR DESCRIPTION
## Summary
- extend context builder with embedding-based retrieval and LLM summarisation
- automatically persist generated context snapshots
- update pipeline and tests for new semantic context workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e62b5e988322aaf8be95705715c3