### PR TITLE
Execute proposal after approval and log metadata

### DIFF
--- a/src/data_processing/proposal_store.py
+++ b/src/data_processing/proposal_store.py
@@ -51,6 +51,7 @@ def record_execution_result(
     block_hash: str,
     outcome: str,
     submission_id: str | None = None,
+    extrinsic_hash: str | None = None,
 ) -> None:
     """Append governor execution details to the ``ExecutionResults`` sheet."""
     row = {
@@ -59,6 +60,7 @@ def record_execution_result(
         "status": status,
         "block_hash": block_hash,
         "outcome": outcome,
+        "extrinsic_hash": extrinsic_hash or "",
     }
     _append_row("ExecutionResults", row)
 

--- a/src/execution/governor_interface.py
+++ b/src/execution/governor_interface.py
@@ -214,3 +214,37 @@ def await_execution(
         time.sleep(poll_interval)
     return "", "timeout"
 
+
+def execute_proposal(
+    node_url: str,
+    private_key: str,
+    remark: str = "Executed by APOLLO",
+) -> Dict[str, Any]:
+    """Dispatch a demo remark extrinsic after a proposal is approved.
+
+    Parameters
+    ----------
+    node_url:
+        Endpoint of the Substrate node.
+    private_key:
+        Private key used to sign the extrinsic.
+    remark:
+        Text included in the ``system.remark`` call.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed receipt information describing the extrinsic execution.
+    """
+
+    substrate = connect(node_url)
+    keypair = _create_keypair(private_key)
+    call = substrate.compose_call(
+        call_module="System",
+        call_function="remark",
+        call_params={"remark": remark.encode("utf-8")},
+    )
+    extrinsic = substrate.create_signed_extrinsic(call=call, keypair=keypair)
+    receipt = substrate.submit_extrinsic(extrinsic, wait_for_inclusion=True)
+    return parse_receipt(receipt)
+

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -52,11 +52,24 @@ def test_main_records_final_status(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(main, "record_proposal", lambda text, sid: None)
     monkeypatch.setattr(main, "await_execution", lambda node_url, idx, sid: ("0xblock", "Approved"))
+    monkeypatch.setattr(
+        main,
+        "execute_proposal",
+        lambda url, pk: {"extrinsic_hash": "0xexec", "block_hash": "0xexecblock"},
+    )
 
     recorded = {}
 
-    def fake_record_execution_result(status, block_hash, outcome, submission_id=None):
-        recorded.update(status=status, block_hash=block_hash, outcome=outcome, submission_id=submission_id)
+    def fake_record_execution_result(
+        status, block_hash, outcome, submission_id=None, extrinsic_hash=None
+    ):
+        recorded.update(
+            status=status,
+            block_hash=block_hash,
+            outcome=outcome,
+            submission_id=submission_id,
+            extrinsic_hash=extrinsic_hash,
+        )
 
     monkeypatch.setattr(main, "record_execution_result", fake_record_execution_result)
 
@@ -68,9 +81,10 @@ def test_main_records_final_status(monkeypatch, tmp_path):
     main.main()
 
     assert recorded == {
-        "status": "Approved",
-        "block_hash": "0xblock",
+        "status": "Executed",
+        "block_hash": "0xexecblock",
         "outcome": "Approved",
         "submission_id": "0xsub",
+        "extrinsic_hash": "0xexec",
     }
     assert captured_kb["query"] == ""


### PR DESCRIPTION
## Summary
- add `execute_proposal` helper to dispatch a demo `system.remark` extrinsic
- trigger proposal execution once a referendum is approved and log extrinsic data
- store extrinsic hashes in execution results for auditability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fee9b1cc8322822268e8dcf8917e