### PR TITLE
Add optional EVM data fetcher

### DIFF
--- a/src/agents/data_collector.py
+++ b/src/agents/data_collector.py
@@ -1,11 +1,13 @@
 """Centralised data collection utilities."""
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, Callable
 
 from data_processing.social_media_scraper import collect_recent_messages
 from data_processing.news_fetcher import fetch_and_summarise_news
 from data_processing.blockchain_cache import get_recent_blocks_cached
+from data_processing.evm_data_fetcher import fetch_evm_blocks
 
 
 class DataCollector:
@@ -16,8 +18,16 @@ class DataCollector:
         msg_fn: Callable[[], list] = collect_recent_messages,
         news_fn: Callable[[], Dict[str, Any]] = fetch_and_summarise_news,
         block_fn: Callable[[], list] = get_recent_blocks_cached,
+        evm_fn: Callable[[], list] | None = None,
     ) -> Dict[str, Any]:
-        """Return recent messages, news summary, and block data."""
+        """Return recent messages, news summary, and block data.
+
+        If the environment variable ``ENABLE_EVM_FETCH`` is set to ``"true"``
+        (case-insensitive), EVM block data will also be collected. A custom
+        function can be supplied via ``evm_fn``; otherwise a default fetcher
+        using :func:`data_processing.evm_data_fetcher.fetch_evm_blocks` is
+        invoked. Results are stored under the ``"evm_blocks"`` key.
+        """
         print("🔄 Collecting social sentiment …")
         messages = msg_fn()
 
@@ -27,4 +37,21 @@ class DataCollector:
         print("🔄 Fetching on-chain data …")
         blocks = block_fn()
 
-        return {"messages": messages, "news": news, "blocks": blocks}
+        result = {"messages": messages, "news": news, "blocks": blocks}
+
+        enable_evm = os.getenv("ENABLE_EVM_FETCH", "false").lower() == "true"
+        if enable_evm:
+            if evm_fn is None:
+                rpc = os.getenv("EVM_RPC_URL", "http://localhost:8545")
+                start = os.getenv("EVM_START_BLOCK")
+                end = os.getenv("EVM_END_BLOCK")
+                start_block = int(start) if start else None
+                end_block = int(end) if end else None
+
+                def evm_fn() -> list:
+                    return fetch_evm_blocks(rpc, start_block, end_block)
+
+            print("🔄 Fetching EVM chain data …")
+            result["evm_blocks"] = evm_fn()
+
+        return result

--- a/src/data_processing/evm_data_fetcher.py
+++ b/src/data_processing/evm_data_fetcher.py
@@ -1,0 +1,65 @@
+"""Utility for fetching block and transaction data from an EVM chain."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from web3 import Web3
+
+DEFAULT_RPC_URL = "http://localhost:8545"
+
+
+def _to_hex(value: Any) -> Any:
+    """Return hex string for bytes-like ``value``.
+
+    Web3 often returns bytes for hashes. Converting them makes the data JSON
+    serialisable and easier to test.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        return "0x" + value.hex()
+    return value
+
+
+def fetch_evm_blocks(
+    rpc_url: str = DEFAULT_RPC_URL,
+    start_block: Optional[int] = None,
+    end_block: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Fetch blocks and full transaction data from an EVM compatible chain.
+
+    Parameters
+    ----------
+    rpc_url: str
+        HTTP RPC endpoint for the chain.
+    start_block: int, optional
+        First block number to fetch. Defaults to ``end_block - 4``.
+    end_block: int, optional
+        Last block number to fetch. Defaults to the chain head.
+    """
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+
+    latest = w3.eth.block_number
+    end = latest if end_block is None else end_block
+    start = max(0, end - 4) if start_block is None else start_block
+
+    blocks: List[Dict[str, Any]] = []
+    for num in range(start, end + 1):
+        block = w3.eth.get_block(num, full_transactions=True)
+        txs = []
+        for tx in block.get("transactions", []):
+            txs.append(
+                {
+                    "hash": _to_hex(tx.get("hash")),
+                    "from": tx.get("from"),
+                    "to": tx.get("to"),
+                    "value": tx.get("value"),
+                }
+            )
+        blocks.append(
+            {
+                "number": block.get("number"),
+                "hash": _to_hex(block.get("hash")),
+                "timestamp": block.get("timestamp"),
+                "transactions": txs,
+            }
+        )
+    return blocks

--- a/tests/test_evm_data_fetcher.py
+++ b/tests/test_evm_data_fetcher.py
@@ -1,0 +1,60 @@
+from agents.data_collector import DataCollector
+from data_processing import evm_data_fetcher
+
+
+def _dummy_web3():
+    class DummyEth:
+        block_number = 1
+
+        def get_block(self, num, full_transactions=True):
+            assert full_transactions is True
+            return {
+                "number": num,
+                "hash": bytes.fromhex("11" * 32),
+                "timestamp": 1000 + num,
+                "transactions": [
+                    {
+                        "hash": bytes.fromhex("22" * 32),
+                        "from": "0xabc",
+                        "to": "0xdef",
+                        "value": 123,
+                    }
+                ],
+            }
+
+    class DummyWeb3:
+        class HTTPProvider:
+            def __init__(self, url):
+                self.url = url
+
+        def __init__(self, provider):
+            self.eth = DummyEth()
+
+    return DummyWeb3
+
+
+def test_fetch_evm_blocks_returns_data(monkeypatch):
+    DummyWeb3 = _dummy_web3()
+    monkeypatch.setattr(evm_data_fetcher, "Web3", DummyWeb3)
+    blocks = evm_data_fetcher.fetch_evm_blocks("http://rpc", start_block=1, end_block=1)
+    assert blocks[0]["number"] == 1
+    assert blocks[0]["hash"].startswith("0x11")
+    assert blocks[0]["transactions"][0]["hash"].startswith("0x22")
+
+
+def test_data_collector_optional_evm(monkeypatch):
+    called = {}
+
+    def dummy_evm_fn():
+        called["called"] = True
+        return [{"number": 1}]
+
+    monkeypatch.setenv("ENABLE_EVM_FETCH", "true")
+    data = DataCollector.collect(
+        msg_fn=lambda: [],
+        news_fn=lambda: {},
+        block_fn=lambda: [],
+        evm_fn=dummy_evm_fn,
+    )
+    assert called["called"] is True
+    assert data["evm_blocks"] == [{"number": 1}]


### PR DESCRIPTION
## Summary
- implement `evm_data_fetcher.fetch_evm_blocks` using Web3
- allow `DataCollector.collect` to gather EVM data via `ENABLE_EVM_FETCH`
- add tests for EVM fetcher and collector integration

## Testing
- `pytest tests/test_evm_data_fetcher.py -q`
