### PR TITLE
Fix proposal save message to use actual filename

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -174,8 +174,10 @@ def main() -> None:
         )
 
     duration = (dt.datetime.utcnow() - start).total_seconds()
-    print(f"\n✅ Proposal saved → {OUT_DIR/'proposal_latest.txt'}   "
-          f"(pipeline took {duration:.1f}s)\n")
+    print(
+        f"\n✅ Proposal saved → {OUT_DIR / f'proposal_{timestamp}.txt'}   "
+        f"(pipeline took {duration:.1f}s)\n"
+    )
     print("----------\n" + proposal_text + "\n----------")
 
 


### PR DESCRIPTION
## Summary
- Ensure final pipeline message shows the actual timestamped proposal file path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68962bb665648322acefe85a3d06ccaf