### PR TITLE
Refactor social media scraping to track sources

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -66,8 +66,10 @@ def main() -> None:
         get_recent_blocks_cached,
     )
 
-    msgs = data["messages"]
-    sentiment = analyse_messages(msgs)
+    msgs_by_source = data["messages"]
+    # Flatten all message lists for sentiment analysis
+    all_msgs = [m for msgs in msgs_by_source.values() for m in msgs]
+    sentiment = analyse_messages(all_msgs)
     # sentiment = []
 
     news = data["news"]

--- a/tests/test_evm_data_fetcher.py
+++ b/tests/test_evm_data_fetcher.py
@@ -51,7 +51,7 @@ def test_data_collector_optional_evm(monkeypatch):
 
     monkeypatch.setenv("ENABLE_EVM_FETCH", "true")
     data = DataCollector.collect(
-        msg_fn=lambda: [],
+        msg_fn=lambda: {},
         news_fn=lambda: {},
         block_fn=lambda: [],
         evm_fn=dummy_evm_fn,

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -19,7 +19,7 @@ def test_main_records_final_status(monkeypatch, tmp_path):
 
     import src.main as main
 
-    monkeypatch.setattr(main, "collect_recent_messages", lambda: [])
+    monkeypatch.setattr(main, "collect_recent_messages", lambda: {})
     monkeypatch.setattr(main, "analyse_messages", lambda msgs: {})
     monkeypatch.setattr(main, "fetch_and_summarise_news", lambda: {})
     monkeypatch.setattr(main, "get_recent_blocks_cached", lambda: [])

--- a/tests/test_proposal_submission.py
+++ b/tests/test_proposal_submission.py
@@ -61,7 +61,7 @@ def test_main_submits(monkeypatch, capsys):
 
     import src.main as main
 
-    monkeypatch.setattr(main, "collect_recent_messages", lambda: [])
+    monkeypatch.setattr(main, "collect_recent_messages", lambda: {})
     monkeypatch.setattr(main, "analyse_messages", lambda msgs: {})
     monkeypatch.setattr(main, "fetch_and_summarise_news", lambda: {})
     monkeypatch.setattr(main, "update_referenda", lambda max_new=500: None)


### PR DESCRIPTION
## Summary
- Refactor social media scraping to return messages grouped by source (chat, forum, news)
- Track per-source message statistics in `DataCollector.collect`
- Adapt main pipeline and tests for new message structure

## Testing
- `pytest -q` *(fails: tests/test_prediction_analysis.py::test_forecast_outcomes_fields_and_ranges)*

------
https://chatgpt.com/codex/tasks/task_e_689b17c8cf148322a5654e821eed8cbe