### PR TITLE
Add data source summary table output

### DIFF
--- a/src/agents/outcome_forecaster.py
+++ b/src/agents/outcome_forecaster.py
@@ -5,7 +5,10 @@ from typing import Dict
 
 import pandas as pd
 
-from data_processing.data_loader import load_governance_data
+try:  # Prefer absolute import so tests can patch via ``src.data_processing``
+    from src.data_processing.data_loader import load_governance_data
+except Exception:  # pragma: no cover
+    from data_processing.data_loader import load_governance_data
 
 
 def forecast_outcomes(context: Dict) -> Dict[str, float]:

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json, pathlib, datetime as dt, os
 from agents.data_collector import DataCollector
 from data_processing.social_media_scraper import collect_recent_messages
+from reporting.summary_tables import print_data_sources_table
 from agents.sentiment_analyser import analyse_messages
 from data_processing.news_fetcher import fetch_and_summarise_news
 from data_processing.referenda_updater import update_referenda
@@ -65,6 +66,9 @@ def main() -> None:
         fetch_and_summarise_news,
         get_recent_blocks_cached,
     )
+
+    # Display summary of collected data sources
+    print_data_sources_table(data["stats"]["data_sources"])
 
     msgs_by_source = data["messages"]
     # Flatten all message lists for sentiment analysis

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -1,0 +1,70 @@
+"""Utilities for printing summary tables about collected data."""
+from __future__ import annotations
+
+from typing import Mapping, Any, Iterable
+
+
+def _format_table(headers: Iterable[str], rows: Iterable[Iterable[Any]]) -> str:
+    """Return a simple ASCII table string.
+
+    This helper determines column widths based on the longest entry in each
+    column and creates a plain table using ``|`` and ``-`` characters.  It is
+    intentionally lightweight to avoid extra dependencies.
+    """
+
+    # Convert all cells to strings for width calculation
+    rows_str = [[str(c) for c in row] for row in rows]
+    headers_str = [str(h) for h in headers]
+
+    # Determine column widths
+    widths = [
+        max(len(headers_str[i]), *(len(row[i]) for row in rows_str))
+        if rows_str
+        else len(headers_str[i])
+        for i in range(len(headers_str))
+    ]
+
+    # Build formatted lines
+    fmt = " | ".join(f"{{:<{w}}}" for w in widths)
+    sep = "-+-".join("-" * w for w in widths)
+
+    lines = [fmt.format(*headers_str), sep]
+    for row in rows_str:
+        lines.append(fmt.format(*row))
+    return "\n".join(lines)
+
+
+def print_data_sources_table(stats: Mapping[str, Mapping[str, Any]]) -> None:
+    """Print a table summarising the collected data sources.
+
+    Parameters
+    ----------
+    stats:
+        Mapping of source type to a dictionary containing at least the keys
+        ``count``, ``avg_word_length`` and ``update_frequency``.  Optional keys
+        ``platform`` or ``url`` may be supplied for display under the
+        ``Platform/URL`` column.  Missing values are represented by ``-``.
+    """
+
+    headers = [
+        "Source Type",
+        "Platform/URL",
+        "# Documents",
+        "Avg. Length",
+        "Update Frequency",
+        ]
+
+    rows = []
+    for source, info in stats.items():
+        platform = info.get("platform") or info.get("url") or "-"
+        count = info.get("count", 0)
+        avg_len = f"{info.get('avg_word_length', 0):.1f}"
+        freq = info.get("update_frequency", "-")
+        rows.append([source, platform, count, avg_len, freq])
+
+    if not rows:
+        print("No data sources available")
+        return
+
+    table = _format_table(headers, rows)
+    print(table)


### PR DESCRIPTION
## Summary
- Add `print_data_sources_table` utility to render a basic ASCII table of collected data sources
- Invoke the table display after data collection in `main.py`
- Make outcome forecaster compatible with tests by importing `data_loader` via the `src` package with fallback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1992401883228a58e142d6a6fd43