### PR TITLE
Track sentiment batch metadata and embedding results

### DIFF
--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -18,9 +18,23 @@ def _require_keys(obj: Dict[str, Any], keys: set[str], label: str):
 
 # ────────────────────────────────────────────────────────────────────────────
 def validate_sentiment(d: Dict[str, Any]) -> bool:
-    _require_keys(d, {"sentiment_score", "summary", "key_topics"}, "sentiment")
+    required = {
+        "sentiment_score",
+        "summary",
+        "key_topics",
+        "sentiment",
+        "confidence",
+        "message_size_kb",
+    }
+    _require_keys(d, required, "sentiment")
     if not (-1 <= d["sentiment_score"] <= 1):
         raise ValueError("sentiment_score outside [-1,1]")
+    if d["sentiment"] not in {"Positive", "Negative", "Mixed"}:
+        raise ValueError("sentiment must be Positive/Negative/Mixed")
+    if not (0 <= d["confidence"] <= 1):
+        raise ValueError("confidence outside [0,1]")
+    if d["message_size_kb"] < 0:
+        raise ValueError("message_size_kb must be non-negative")
     return True
 
 

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -7,7 +7,14 @@ from llm import ollama_api
 
 
 def _dummy_components():
-    sentiment = {"sentiment_score": 0, "summary": "ok", "key_topics": []}
+    sentiment = {
+        "sentiment_score": 0,
+        "summary": "ok",
+        "key_topics": [],
+        "sentiment": "Mixed",
+        "confidence": 0.0,
+        "message_size_kb": 0.0,
+    }
     news = {"digest": [], "risks": ""}
     chain = {
         "daily_tx_count": {},
@@ -46,6 +53,7 @@ def test_build_context_structure_dedup_and_summary(monkeypatch):
         "governance_kpis",
         "kb_snippets",
         "kb_summary",
+        "kb_embedded",
     }
     assert ctx["kb_snippets"] == ["previous proposal"]
     assert ctx["kb_summary"] == "summary"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -15,6 +15,9 @@ def test_validators_pass_on_dummy():
         "sentiment_score": 0.1,
         "summary": "ok",
         "key_topics": [],
+        "sentiment": "Positive",
+        "confidence": 0.1,
+        "message_size_kb": 0.5,
     }
     news = {"digest": [], "risks": ""}
     chain = {


### PR DESCRIPTION
## Summary
- Expose sentiment label, confidence, and message size in `analyse_messages`
- Track knowledge base embedding success in context generator and context output
- Log per-source sentiment batch stats with embedding flags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1ecbe1548322835b87f64400dbf0