### PR TITLE
Add sentiment embedding summary table

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 import json, pathlib, datetime as dt, os
 from agents.data_collector import DataCollector
 from data_processing.social_media_scraper import collect_recent_messages
-from reporting.summary_tables import print_data_sources_table
+from reporting.summary_tables import (
+    print_data_sources_table,
+    print_sentiment_embedding_table,
+)
 from agents.sentiment_analyser import analyse_messages
 from data_processing.news_fetcher import fetch_and_summarise_news
 from data_processing.referenda_updater import update_referenda
@@ -124,6 +127,8 @@ def main() -> None:
         kb_query=query,
         summarise_snippets=True,
     )
+    # Display sentiment analysis and embedding stats
+    print_sentiment_embedding_table(stats.get("sentiment_batches", []))
     forecast = forecast_outcomes(context)
     context["forecast"] = forecast
     timestamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -68,3 +68,41 @@ def print_data_sources_table(stats: Mapping[str, Mapping[str, Any]]) -> None:
 
     table = _format_table(headers, rows)
     print(table)
+
+
+def print_sentiment_embedding_table(stats: Iterable[Mapping[str, Any]]) -> None:
+    """Print a table summarising sentiment analysis batches.
+
+    Parameters
+    ----------
+    stats:
+        Iterable of dictionaries each describing one sentiment analysis batch
+        with the keys ``batch_id``, ``source``, ``ctx_size_kb``, ``sentiment``,
+        ``confidence`` and ``embedded``.
+    """
+
+    headers = [
+        "Batch",
+        "Source",
+        "Ctx Size (KB)",
+        "Sentiment",
+        "Confidence",
+        "Embedded",
+    ]
+
+    rows = []
+    for info in stats:
+        batch = info.get("batch_id", "-")
+        source = info.get("source", "-")
+        size = f"{info.get('ctx_size_kb', 0.0):.1f}"
+        sent = info.get("sentiment", "-")
+        conf = f"{info.get('confidence', 0.0):.2f}"
+        embedded = "yes" if info.get("embedded") else "no"
+        rows.append([batch, source, size, sent, conf, embedded])
+
+    if not rows:
+        print("No sentiment batches available")
+        return
+
+    table = _format_table(headers, rows)
+    print(table)


### PR DESCRIPTION
## Summary
- Add `print_sentiment_embedding_table` to show sentiment batches with embedding status
- Display sentiment/embedding stats in main pipeline after context building

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b222d57e883229fa62315379c271c