### PR TITLE
Add global stats tracking and summary table output

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,15 @@
-# Make src a Python package
+"""APOLLO Governance Proposal System package."""
+
+from .reporting.summary_tables import (
+    print_data_sources_table,
+    print_sentiment_embedding_table,
+    print_prediction_accuracy_table,
+    print_timing_benchmarks_table,
+)
+
+__all__ = [
+    "print_data_sources_table",
+    "print_sentiment_embedding_table",
+    "print_prediction_accuracy_table",
+    "print_timing_benchmarks_table",
+]


### PR DESCRIPTION
## Summary
- Initialize a global `stats` dict in `main` and feed it through the pipeline to collect metrics.
- Output proposal metrics tables (data sources, sentiment, predictions, timing) after the proposal text.
- Expose summary table helpers at the package root for external use.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b397052988322b3b06c428a42e387