### PR TITLE
Replace deprecated utcnow with timezone-aware datetimes

### DIFF
--- a/src/analysis/blockchain_metrics.py
+++ b/src/analysis/blockchain_metrics.py
@@ -44,7 +44,7 @@ def summarise_blocks(blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
     total_tx, total_fee, n_blocks = 0, 0.0, 0
 
     for blk in blocks:
-        ts = dt.datetime.utcfromtimestamp(blk["block_timestamp"])
+        ts = dt.datetime.fromtimestamp(blk["block_timestamp"], dt.UTC)
         day = ts.strftime("%Y-%m-%d")
         hour_key = ts.strftime("%Y-%m-%d %H:00")
 

--- a/src/analysis/news_analysis.py
+++ b/src/analysis/news_analysis.py
@@ -28,15 +28,15 @@ LOOKBACK_DAYS = 25          # only keep recent items
 def _fetch_rss_items() -> List[Dict[str, Any]]:
     """Collect items from RSS feeds and filter by recency."""
     items: list[dict] = []
-    cutoff = dt.datetime.utcnow() - dt.timedelta(days=LOOKBACK_DAYS)
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=LOOKBACK_DAYS)
 
     for url in RSS_FEEDS:
         feed = feedparser.parse(url)
         for entry in feed.entries:
             published = (
-                dt.datetime(*entry.published_parsed[:6])
+                dt.datetime(*entry.published_parsed[:6], tzinfo=dt.UTC)
                 if "published_parsed" in entry
-                else dt.datetime.utcnow()
+                else dt.datetime.now(dt.UTC)
             )
             if published < cutoff:
                 continue

--- a/src/data_processing/blockchain_cache.py
+++ b/src/data_processing/blockchain_cache.py
@@ -48,8 +48,10 @@ def _cache_latest_timestamp(blocks: List[Dict[str, Any]]) -> int:
 
 
 def _is_too_old(blocks: List[Dict[str, Any]]) -> bool:
-    age_days = (dt.datetime.utcnow() -
-                dt.datetime.utcfromtimestamp(_cache_latest_timestamp(blocks))).days
+    age_days = (
+        dt.datetime.now(dt.UTC)
+        - dt.datetime.fromtimestamp(_cache_latest_timestamp(blocks), dt.UTC)
+    ).days
     return age_days > MAX_AGE_DAYS
 
 

--- a/src/data_processing/blockchain_data_fetcher.py
+++ b/src/data_processing/blockchain_data_fetcher.py
@@ -74,7 +74,10 @@ def fetch_recent_blocks() -> Tuple[List[Dict[str, Any]], Dict[str, Dict[str, Any
     per_day: dict[str, dict[str, Any]] = {}
     n_calls = 0
 
-    print(f"Starting from block {latest} - Time: {dt.datetime.utcfromtimestamp(chain_now_ts)}, looking back to UTC {dt.datetime.utcfromtimestamp(cutoff_ts)}")
+    print(
+        f"Starting from block {latest} - Time: {dt.datetime.fromtimestamp(chain_now_ts, dt.UTC)}, "
+        f"looking back to UTC {dt.datetime.fromtimestamp(cutoff_ts, dt.UTC)}"
+    )
     for num in range(latest, 0, -1):
         ts = _get_block_timestamp(substrate, num)
         if ts < cutoff_ts:
@@ -98,7 +101,7 @@ def fetch_recent_blocks() -> Tuple[List[Dict[str, Any]], Dict[str, Dict[str, Any
         blocks.append(data)
 
         # Aggregate
-        day = dt.datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d")
+        day = dt.datetime.fromtimestamp(ts, dt.UTC).strftime("%Y-%m-%d")
         per_day.setdefault(day, {"txs": 0, "fee": 0.0})
         per_day[day]["txs"] += data.get("extrinsics_count", 0)
         per_day[day]["fee"] += float(data.get("total_fee", 0)) / 10**10  # plancks→DOT

--- a/src/data_processing/news_fetcher.py
+++ b/src/data_processing/news_fetcher.py
@@ -38,14 +38,14 @@ def _parse_entry(entry) -> Dict[str, Any]:
     return {
         "title": entry.title,
         "summary": BeautifulSoup(getattr(entry, "summary", ""), "html.parser").get_text()[:280],
-        "published": dt.datetime(*entry.published_parsed[:6])
+        "published": dt.datetime(*entry.published_parsed[:6], tzinfo=dt.UTC)
         if getattr(entry, "published_parsed", None)
-        else dt.datetime.utcnow(),
+        else dt.datetime.now(dt.UTC),
     }
 
 
 def _collect_recent_items() -> List[Dict[str, Any]]:
-    cutoff = dt.datetime.utcnow() - dt.timedelta(days=LOOKBACK_DAYS)
+    cutoff = dt.datetime.now(dt.UTC) - dt.timedelta(days=LOOKBACK_DAYS)
     items: list[dict] = []
     for url in RSS_FEEDS:
         for e in feedparser.parse(url).entries:

--- a/src/data_processing/referenda_updater.py
+++ b/src/data_processing/referenda_updater.py
@@ -52,7 +52,11 @@ NUMERIC_COLS = {
     "Total_Voted_DOT", "Eligible_DOT", "Not_Perticipated_DOT", "Voted_percentage"
 }
 
-to_iso  = lambda ts: dt.datetime.utcfromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S") if ts else ""
+to_iso  = (
+    lambda ts: dt.datetime.fromtimestamp(ts, dt.UTC).strftime("%Y-%m-%d %H:%M:%S")
+    if ts
+    else ""
+)
 strip_h = lambda h: BeautifulSoup(h, "html.parser").get_text(" ", strip=True)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -69,7 +69,7 @@ def broadcast_proposal(text: str) -> None:
 
 
 def main() -> None:
-    start = dt.datetime.utcnow()
+    start = dt.datetime.now(dt.UTC)
     stats: dict[str, Any] = {}
     phase_times: dict[str, float] = {}
 
@@ -152,7 +152,7 @@ def main() -> None:
                     if forecast.get("approval_prob", 0.0) >= 0.5
                     else "Rejected",
                     "confidence": forecast.get("approval_prob", 0.0),
-                    "prediction_time": dt.datetime.utcnow().isoformat(),
+                    "prediction_time": dt.datetime.now(dt.UTC).isoformat(),
                     "margin_of_error": forecast.get("turnout_estimate", 0.0),
                 }
             ]
@@ -161,7 +161,7 @@ def main() -> None:
         stats["prediction_eval"] = eval_res.get("prediction_eval", [])
     except Exception:
         stats["prediction_eval"] = []
-    timestamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d-%H%M%S")
     (OUT_DIR / f"context_{timestamp}.json").write_text(json.dumps(context, indent=2))
     phase_times["analysis_prediction_s"] = time.perf_counter() - t1
 
@@ -169,7 +169,7 @@ def main() -> None:
     t2 = time.perf_counter()
     print("🔄 Asking LLM to draft proposal …")
     proposal_text = proposal_generator.draft(context)
-    timestamp = dt.datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%d-%H%M%S")
     (OUT_DIR / f"proposal_{timestamp}.txt").write_text(proposal_text)
     broadcast_proposal(proposal_text)
 
@@ -270,7 +270,7 @@ def main() -> None:
     except Exception:
         pass
 
-    duration = (dt.datetime.utcnow() - start).total_seconds()
+    duration = (dt.datetime.now(dt.UTC) - start).total_seconds()
     print(
         f"\n✅ Proposal saved → {OUT_DIR / f'proposal_{timestamp}.txt'}   "
         f"(pipeline took {duration:.1f}s)\n"

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -49,12 +49,12 @@ def extract_json_safe(text: str) -> Optional[Dict[str, Any]]:
 # ────────────────────────────────────────────────────────────────────────────
 def utc_now_iso() -> str:
     """UTC timestamp like 2025-05-17T13:55:02Z."""
-    return dt.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return dt.datetime.now(dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def days_ago_iso(days: int) -> str:
     """ISO date N days ago (UTC)."""
-    return (dt.datetime.utcnow() - dt.timedelta(days=days)).strftime("%Y-%m-%d")
+    return (dt.datetime.now(dt.UTC) - dt.timedelta(days=days)).strftime("%Y-%m-%d")
 
 
 # ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- use `datetime.now(dt.UTC)` instead of deprecated `datetime.utcnow()` across the pipeline
- convert timestamp helpers and scrapers to `datetime.fromtimestamp(..., dt.UTC)` to keep comparisons timezone-aware

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b9ffcf1188322af938f3b9e128ae5