### PR TITLE
Ensure Referenda sheet is used when updating IDs

### DIFF
--- a/src/agents/proposal_generator.py
+++ b/src/agents/proposal_generator.py
@@ -30,5 +30,5 @@ def draft(context_dict: Dict[str, Any]) -> str:
         system="You are Polkadot-Gov-Agent v1.",
         model="gemma3:4b",
         temperature=0.3,
-        max_tokens=4096,
+        max_tokens=2048,
     )

--- a/src/data_processing/referenda_updater.py
+++ b/src/data_processing/referenda_updater.py
@@ -220,8 +220,9 @@ def collect_referendum(idx: int) -> Dict[str, str | int | float]:
 
 # ───────────────────── last stored id ──────────────────────────────────
 def last_stored_id() -> int:
-    if not XLSX_PATH.exists(): return -1
-    df = load_first_sheet()
+    if not XLSX_PATH.exists():
+        return -1
+    df = pd.read_excel(XLSX_PATH, sheet_name="Referenda")
     ids = pd.to_numeric(df.iloc[:, 0], errors="coerce").dropna()
     return int(ids.iloc[-1]) if not ids.empty else -1
 
@@ -231,7 +232,11 @@ def update_referenda(max_new: int = 500, max_gaps: int = 5) -> None:
     last = last_stored_id()
     print(f"Last Referendum_ID in workbook: {last}")
 
-    df = pd.read_excel(XLSX_PATH) if XLSX_PATH.exists() else pd.DataFrame(columns=COLS)
+    df = (
+        pd.read_excel(XLSX_PATH, sheet_name="Referenda")
+        if XLSX_PATH.exists()
+        else pd.DataFrame(columns=COLS)
+    )
     failures: List[Dict[str, str]] = []
     attempted = gap_streak = 0
     next_id = last + 1


### PR DESCRIPTION
## Summary
- Read the `Referenda` worksheet directly when determining the last stored referendum ID
- Load the `Referenda` worksheet explicitly in the updater routine
- Align proposal drafting with tests by capping generated token count at 2048

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb3d1ba208322b152674cac78fdc2