### PR TITLE
Raise missing openpyxl errors for proposal storage

### DIFF
--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,5 +1,7 @@
 import pandas as pd
 from data_processing import proposal_store
+import builtins
+import pytest
 
 
 def test_search_proposals_returns_matches(monkeypatch):
@@ -13,4 +15,20 @@ def test_search_proposals_returns_matches(monkeypatch):
 
     results = proposal_store.search_proposals("governance", limit=5)
     assert results == ["Improve governance transparency"]
+
+
+def test_missing_openpyxl_raises(monkeypatch):
+    """Ensure a helpful error surfaces when ``openpyxl`` is unavailable."""
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "openpyxl":
+            raise ImportError("openpyxl is missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.warns(UserWarning, match="openpyxl is required"):
+        with pytest.raises(ImportError):
+            proposal_store.record_proposal("text", None)
 


### PR DESCRIPTION
## Summary
- warn and re-raise if openpyxl is missing when storing proposals
- test that missing openpyxl surfaces an informative error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb6b1ace0832290bbf1aa34c5c7f9