### PR TITLE
Add proposal store persistence test

### DIFF
--- a/tests/test_proposal_persistence.py
+++ b/tests/test_proposal_persistence.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from data_processing import proposal_store
+
+
+def test_record_proposal_persists(tmp_path, monkeypatch):
+    temp_xlsx = tmp_path / "store.xlsx"
+    monkeypatch.setattr(proposal_store, "XLSX_PATH", temp_xlsx)
+
+    proposal_store.record_proposal("Test proposal text", submission_id="ABC123")
+
+    df = pd.read_excel(temp_xlsx, sheet_name="Proposals")
+
+    assert len(df) == 1
+    assert df.loc[0, "proposal_text"] == "Test proposal text"
+    assert df.loc[0, "submission_id"] == "ABC123"


### PR DESCRIPTION
## Summary
- test that `record_proposal` writes to workbook and can be read back

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb8a774a48322815c4de3e7911146