### PR TITLE
chore: remove unused load_first_sheet import

### DIFF
--- a/src/data_processing/referenda_updater.py
+++ b/src/data_processing/referenda_updater.py
@@ -20,7 +20,6 @@ import pandas as pd
 from bs4 import BeautifulSoup
 from substrateinterface import SubstrateInterface
 
-from data_processing.data_loader import load_first_sheet
 from data_processing.proposal_store import ensure_workbook
 from utils.helpers import extract_json_safe, utc_now_iso
 


### PR DESCRIPTION
## Summary
- remove unused `load_first_sheet` import from referenda updater

## Testing
- `rg load_first_sheet -n src/data_processing/referenda_updater.py`
- `pytest -q`
