### PR TITLE
docs: document governance workbook structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ APOLLO’s modular architecture is deployable on any blockchain supporting on-ch
 ### 📦 Features
 
 - **LLM-Based Analysis:** Uses open-source LLMs (e.g., Gemma3:4B, Deepseek R1:1.5B) via Ollama for summarization, classification, and proposal generation.
-- **Retrieval-Augmented Knowledge Base:** Stores historical proposals in an Excel workbook (`data/input/PKD Governance Data.xlsx`, generated at runtime) for retrieval-augmented generation (RAG).
+- **Retrieval-Augmented Knowledge Base:** Stores governance data in an Excel workbook (`data/input/PKD Governance Data.xlsx`, auto-generated if missing) for retrieval-augmented generation (RAG). See [docs/workbook_structure.md](docs/workbook_structure.md) for worksheet details.
 - **Predictive Outcome Modeling (planned):** Lightweight ML models to forecast proposal success and voter turnout (not yet implemented).
 - **Chain-Agnostic Design:** Integrates with Polkadot’s OpenGov pallet; easily adaptable to other platforms.
 - **Modular Pipeline:** Separate modules for data collection, analysis, LLM inference, and on-chain logging.

--- a/docs/workbook_structure.md
+++ b/docs/workbook_structure.md
@@ -1,0 +1,15 @@
+# Governance Workbook Structure
+
+APOLLO stores governance data in an Excel workbook at `data/input/PKD Governance Data.xlsx`. The file is created automatically if it does not exist when data is recorded.
+
+## Default Sheets
+
+- **Referenda** – snapshots of referendum metadata pulled from the chain for audit and analysis.
+- **Proposals** – generated proposal texts along with optional submission identifiers.
+- **ExecutionResults** – details about on-chain execution attempts, such as status, block hash, and outcome.
+
+## Optional Sheets
+
+- **Context** – structured context blobs captured for traceability; this sheet appears only when context is recorded.
+
+Additional sheets may be added by future features, but these are the core ones currently used.


### PR DESCRIPTION
## Summary
- add workbook structure documentation detailing default and optional sheets
- reference the documentation from README

## Testing
- `pytest -q`
