### PR TITLE
Handle missing Context sheet in governance loader

### DIFF
--- a/src/data_processing/data_loader.py
+++ b/src/data_processing/data_loader.py
@@ -33,7 +33,11 @@ def load_governance_data(sheet_name=None):
         except Exception as e:
             print(f"❌ Failed to create workbook: {e}")
         if sheet_name is None:
-            return {s: pd.DataFrame() for s in ("Referenda", "Proposals", "ExecutionResults")}
+            return {
+                s: pd.DataFrame()
+                for s in ("Referenda", "Proposals", "ExecutionResults", "Context")
+            }
+        # Requested sheet (including "Context") should yield an empty DataFrame
         return pd.DataFrame()
     except Exception as e:
         print(f"❌ Error loading data: {e}")

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,39 @@
+import pandas as pd
+from pathlib import Path
+
+from data_processing import data_loader
+
+
+def _fake_read_excel(*args, **kwargs):
+    raise FileNotFoundError
+
+
+def test_missing_workbook_returns_all_empty(monkeypatch, tmp_path):
+    fake_path = tmp_path / "missing.xlsx"
+    monkeypatch.setattr(data_loader, "FILE_PATH", fake_path)
+    monkeypatch.setattr(data_loader, "XLSX_PATH", fake_path)
+    monkeypatch.setattr(data_loader, "ensure_workbook", lambda: None)
+    monkeypatch.setattr(data_loader.pd, "read_excel", _fake_read_excel)
+
+    data = data_loader.load_governance_data()
+
+    assert set(data.keys()) == {
+        "Referenda",
+        "Proposals",
+        "ExecutionResults",
+        "Context",
+    }
+    assert all(isinstance(df, pd.DataFrame) and df.empty for df in data.values())
+
+
+def test_missing_workbook_context_sheet(monkeypatch, tmp_path):
+    fake_path = tmp_path / "missing.xlsx"
+    monkeypatch.setattr(data_loader, "FILE_PATH", fake_path)
+    monkeypatch.setattr(data_loader, "XLSX_PATH", fake_path)
+    monkeypatch.setattr(data_loader, "ensure_workbook", lambda: None)
+    monkeypatch.setattr(data_loader.pd, "read_excel", _fake_read_excel)
+
+    df = data_loader.load_governance_data(sheet_name="Context")
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty


### PR DESCRIPTION
## Summary
- Include `Context` worksheet in fallback dictionary when governance workbook is absent
- Ensure a requested sheet, including `Context`, returns an empty DataFrame if the workbook is missing
- Add tests covering `Context` sheet handling in `load_governance_data`

## Testing
- `pytest tests/test_data_loader.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc15efc308322846290b10890e9cb