### PR TITLE
Add test for governance workbook creation

### DIFF
--- a/tests/test_workbook_creation.py
+++ b/tests/test_workbook_creation.py
@@ -1,0 +1,14 @@
+from data_processing import proposal_store
+from openpyxl import load_workbook
+
+
+def test_ensure_workbook_creates_required_sheets(tmp_path, monkeypatch):
+    tmp_xlsx = tmp_path / "gov.xlsx"
+    monkeypatch.setattr(proposal_store, "XLSX_PATH", tmp_xlsx)
+
+    proposal_store.ensure_workbook()
+    wb = load_workbook(tmp_xlsx)
+
+    expected = {"Referenda", "Proposals", "Context", "ExecutionResults"}
+    assert set(wb.sheetnames) == expected
+    assert "Sheet" not in wb.sheetnames


### PR DESCRIPTION
## Summary
- add test verifying ensure_workbook creates required sheets and removes default 'Sheet'

## Testing
- `pytest tests/test_workbook_creation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc3b83ebc8322870e42f0c8847872