### PR TITLE
Add platform mapping to data source stats

### DIFF
--- a/src/agents/data_collector.py
+++ b/src/agents/data_collector.py
@@ -46,6 +46,14 @@ class DataCollector:
             "forum": "daily",
             "news": "hourly",
         }
+        platform_map = {
+            "chat": "X (@PolkadotNetwork), Reddit (r/Polkadot)",
+            "forum": "https://forum.polkadot.network",
+            "news": (
+                "https://cryptorank.io/news/polkadot; "
+                "https://www.binance.com/en/square/post"
+            ),
+        }
         if stats is None:
             stats = {}
         stats.setdefault("data_sources", {})
@@ -58,6 +66,7 @@ class DataCollector:
                 "count": count,
                 "avg_word_length": avg_words,
                 "update_frequency": update_freq.get(source, "unknown"),
+                "platform": platform_map.get(source),
             }
 
         print("🔄 Fetching news …")


### PR DESCRIPTION
## Summary
- map data collection sources to human-readable platforms/URLs
- include platform info in data source statistics

## Testing
- `pytest` *(fails: expected call not found in test_proposal_generator.py)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_689bd268ed248322a721d7c0fd603416