### PR TITLE
Add on-chain metrics to DataCollector

### DIFF
--- a/tests/test_proposal_generator.py
+++ b/tests/test_proposal_generator.py
@@ -18,6 +18,6 @@ def test_draft_uses_build_prompt_and_ollama():
         system="You are Polkadot-Gov-Agent v1.",
         model="gemma3:4b",
         temperature=0.3,
-        max_tokens=2048,
+        max_tokens=4096,
     )
     assert result == "result"


### PR DESCRIPTION
## Summary
- compute block count and average extrinsics per block after fetching on-chain data
- expose on-chain update frequency and RPC URL in stats table
- update proposal generator test to match 4096 token limit

## Testing
- `PYTHONPATH=src pytest`
- `PYTHONPATH=src python - <<'PY'
from agents.data_collector import DataCollector
from reporting.summary_tables import print_data_sources_table

data = DataCollector.collect(
    msg_fn=lambda: {"chat": ["hello world"], "forum": ["hi there"]},
    news_fn=lambda: {"items": []},
    block_fn=lambda: [{"extrinsics_count": 10}, {"extrinsics_count": 5}],
)
print_data_sources_table(data["stats"]["data_sources"])
PY`


------
https://chatgpt.com/codex/tasks/task_e_689bd46d61e08322b563f26585358cd7