### PR TITLE
Handle proposal stages and link execution results

### DIFF
--- a/tests/test_proposal_persistence.py
+++ b/tests/test_proposal_persistence.py
@@ -16,3 +16,26 @@ def test_record_proposal_persists(tmp_path, monkeypatch):
     assert df.loc[0, "proposal_text"] == "Test proposal text"
     assert df.loc[0, "submission_id"] == "ABC123"
     assert df.loc[0, "stage"] == "draft"
+
+
+def test_stage_column_added_if_missing(tmp_path, monkeypatch):
+    """Existing sheets lacking ``stage`` gain the column on write."""
+
+    temp_xlsx = tmp_path / "store.xlsx"
+    monkeypatch.setattr(proposal_store, "XLSX_PATH", temp_xlsx)
+
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Proposals"
+    ws.append(["timestamp", "proposal_text", "submission_id"])
+    ws.append(["t1", "Old", "111"])
+    wb.save(temp_xlsx)
+    wb.close()
+
+    proposal_store.record_proposal("New", submission_id="222", stage="draft")
+
+    df = pd.read_excel(temp_xlsx, sheet_name="Proposals", dtype=str)
+    assert "stage" in df.columns
+    assert df.loc[df["submission_id"] == "222", "stage"].iat[0] == "draft"

--- a/tests/test_record_execution_result.py
+++ b/tests/test_record_execution_result.py
@@ -25,3 +25,27 @@ def test_record_execution_updates_referenda(tmp_path, monkeypatch):
     )
 
     assert called.get("idx") == 42
+
+
+def test_execution_result_links_to_proposal(tmp_path, monkeypatch):
+    from src.data_processing import proposal_store
+
+    temp_xlsx = tmp_path / "store.xlsx"
+    monkeypatch.setattr(proposal_store, "XLSX_PATH", temp_xlsx)
+
+    proposal_store.record_proposal("Draft", None, stage="draft")
+    proposal_store.record_proposal("Final", "SID", stage="submitted")
+
+    proposal_store.record_execution_result(
+        status="Executed",
+        block_hash="0x",
+        outcome="Approved",
+        submission_id="SID",
+    )
+
+    import pandas as pd
+
+    df_exec = pd.read_excel(temp_xlsx, sheet_name="ExecutionResults")
+    df_prop = pd.read_excel(temp_xlsx, sheet_name="Proposals")
+    submitted_row = df_prop.index[df_prop["submission_id"] == "SID"][0] + 2
+    assert int(df_exec.loc[0, "proposal_row"]) == submitted_row


### PR DESCRIPTION
## Summary
- Allow proposal storage to dynamically add missing columns like `stage`
- Track proposal workflow stage and link execution results back to the submitted proposal row
- Cover stage column upgrades and execution-result linkage with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0590a55908322a63030a32c9b6430