### PR TITLE
Make historical sampling seed configurable

### DIFF
--- a/.env
+++ b/.env
@@ -12,3 +12,5 @@ TELEGRAM_CHAT_ID=your_chat_id
 TWITTER_BEARER=your_twitter_api_bearer_token
 # News fetcher configuration
 NEWS_LOOKBACK_DAYS=3
+# Optional: Seed for sampling historical referenda
+HISTORICAL_SAMPLE_SEED=0

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Create a `.env` file in the project root:
 
  # Recency controls
  NEWS_LOOKBACK_DAYS=3          # days of news to fetch
+ # Fallback historical evaluation
+ HISTORICAL_SAMPLE_SEED=0      # optional seed for sampling historical referenda
 ```
 
 `SUBSTRATE_NODE_URL` should point to a Substrate RPC endpoint. Common choices
@@ -217,7 +219,9 @@ Telegram, and Twitter variables enable posting proposal summaries to those
 platforms via the execution layer connectors.
 
 `NEWS_LOOKBACK_DAYS` controls the number of past days of RSS items retrieved by
-the news fetcher.
+the news fetcher. `HISTORICAL_SAMPLE_SEED` can be set to an integer to make
+historical prediction sampling reproducible; omit it to allow nondeterministic
+selection.
 
 #### Data Weighting System
 

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import os
 from typing import Any, Iterable, Mapping
 
 import pandas as pd
@@ -202,7 +203,15 @@ def evaluate_historical_predictions(sample_size: int = 5) -> list[dict[str, Any]
     if df_done.empty:
         return []
 
-    sample_df = df_done.sample(n=min(sample_size, len(df_done)), random_state=0)
+    seed = os.getenv("HISTORICAL_SAMPLE_SEED")
+    sample_kwargs = {"n": min(sample_size, len(df_done))}
+    if seed:
+        try:
+            sample_kwargs["random_state"] = int(seed)
+        except ValueError:
+            pass
+
+    sample_df = df_done.sample(**sample_kwargs)
 
     title_col = next((col_map[c] for c in ["title", "name"] if c in col_map), None)
     summary_col = next(

--- a/tests/test_historical_prediction_fallback.py
+++ b/tests/test_historical_prediction_fallback.py
@@ -20,10 +20,16 @@ def test_historical_prediction_fallback(monkeypatch):
         "src.agents.outcome_forecaster.load_governance_data", lambda sheet_name="Referenda": df
     )
 
+    # Ensure deterministic sampling
+    monkeypatch.setenv("HISTORICAL_SAMPLE_SEED", "0")
+
     results = evaluate_historical_predictions(sample_size=5)
 
     # Only three referenda are eligible despite requesting five
     assert len(results) == 3
+
+    # Sample order should be deterministic due to seed
+    assert [r["Proposal ID"] for r in results] == [3, 2, 1]
 
     for res in results:
         assert res.get("Predicted")


### PR DESCRIPTION
## Summary
- Allow `evaluate_historical_predictions` to use optional `HISTORICAL_SAMPLE_SEED` env var instead of a hard-coded `random_state`
- Document `HISTORICAL_SAMPLE_SEED` in README and `.env` template
- Ensure tests set `HISTORICAL_SAMPLE_SEED` for deterministic historical sampling

## Testing
- `pytest tests/test_historical_prediction_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a05e52dd7c8322aa07b0c1a917499b