### PR TITLE
Add draft forecast table with confidence threshold

### DIFF
--- a/.env
+++ b/.env
@@ -14,3 +14,5 @@ TWITTER_BEARER=your_twitter_api_bearer_token
 NEWS_LOOKBACK_DAYS=3
 # Optional: Seed for sampling historical referenda
 HISTORICAL_SAMPLE_SEED=0
+# Threshold for labelling a draft as passing
+MIN_PASS_CONFIDENCE=0.80

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Create a `.env` file in the project root:
  NEWS_LOOKBACK_DAYS=3          # days of news to fetch
  # Fallback historical evaluation
  HISTORICAL_SAMPLE_SEED=0      # optional seed for sampling historical referenda
+ # Minimum confidence to label a draft as passing
+ MIN_PASS_CONFIDENCE=0.80
 ```
 
 `SUBSTRATE_NODE_URL` should point to a Substrate RPC endpoint. Common choices
@@ -221,7 +223,8 @@ platforms via the execution layer connectors.
 `NEWS_LOOKBACK_DAYS` controls the number of past days of RSS items retrieved by
 the news fetcher. `HISTORICAL_SAMPLE_SEED` can be set to an integer to make
 historical prediction sampling reproducible; omit it to allow nondeterministic
-selection.
+selection. `MIN_PASS_CONFIDENCE` defines the approval probability threshold used
+to label draft proposals as "Pass" in the forecast summary table.
 
 #### Data Weighting System
 
@@ -290,7 +293,7 @@ twitter_post("Example proposal summary")
 
 ### 7. Review Prediction Accuracy
 
-After `main.py` completes, APOLLO prints a prediction‑accuracy table comparing forecasted outcomes with actual referendum results. When no current evaluations are available, the system samples five historical executed referenda to populate this table.
+After `main.py` completes, APOLLO prints a prediction‑accuracy table comparing forecasted outcomes with actual referendum results. It also prints a draft forecast table listing each generated draft, its predicted outcome, confidence, runtime and margin of error. When no current evaluations are available, the system samples five historical executed referenda to populate this table.
 
 > **Prerequisite:** `data/input/PKD Governance Data.xlsx` must exist and include executed referenda (e.g., populate it via `python src/data_processing/referenda_updater.py`). Without this data the fallback accuracy report cannot be generated.
 

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -347,3 +347,37 @@ def print_sentiment_embedding_table(stats: Iterable[Mapping[str, Any]]) -> None:
     print("\nTable: Sentiment Analysis and Knowledge Base Embedding")
     table = _format_table(headers, rows)
     print(table)
+
+
+def print_draft_forecast_table(stats: Iterable[Mapping[str, Any]]) -> None:
+    """Print a table of proposal draft outcome forecasts."""
+
+    headers = [
+        "Source Type",
+        "Title",
+        "Predicted",
+        "Confidence (%)",
+        "Prediction Time (s)",
+        "Margin of Error",
+    ]
+
+    rows = []
+    for info in stats:
+        rows.append(
+            [
+                info.get("source", "-"),
+                info.get("title", "-"),
+                info.get("predicted", "-"),
+                f"{info.get('confidence', 0.0) * 100:.1f}",
+                f"{info.get('prediction_time', 0.0):.2f}",
+                f"{info.get('margin_of_error', 0.0):.2f}",
+            ]
+        )
+
+    if not rows:
+        print("No draft predictions available")
+        return
+
+    print("\nTable: Draft Outcome Forecasts")
+    table = _format_table(headers, rows)
+    print(table)

--- a/tests/test_draft_forecast_table.py
+++ b/tests/test_draft_forecast_table.py
@@ -1,0 +1,18 @@
+import importlib
+
+from src import main
+
+
+def test_drafts_under_threshold_label_fail(monkeypatch):
+    monkeypatch.setenv("MIN_PASS_CONFIDENCE", "0.9")
+    importlib.reload(main)
+    drafts = [
+        {
+            "source": "chat",
+            "text": "# Title\nBody",
+            "forecast": {"approval_prob": 0.5, "turnout_estimate": 0.1},
+            "prediction_time": 0.01,
+        }
+    ]
+    records = main.summarise_draft_predictions(drafts, main.MIN_PASS_CONFIDENCE)
+    assert records[0]["predicted"] == "Fail"


### PR DESCRIPTION
## Summary
- Read `MIN_PASS_CONFIDENCE` to classify draft forecasts and compute prediction metrics
- Print new draft forecast table summarising outcome predictions
- Document `MIN_PASS_CONFIDENCE` and add tests for fail labelling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a05fc4502c8322928ccf640e85d9b8