### PR TITLE
feat: print draft success forecast table

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,17 @@ twitter_post("Example proposal summary")
 
 After `main.py` completes, APOLLO prints a prediction‑accuracy table comparing forecasted outcomes with actual referendum results. It also prints a draft forecast table listing each generated draft, its predicted outcome, confidence, runtime and margin of error. When no current evaluations are available, the system samples five historical executed referenda to populate this table.
 
+Example output:
+
+Drafted proposal success prediction and forecast (Pass confidence threshold <80%)
+
+| Source Type | Title | Predicted | Confidence (%) | Prediction Time (s) | Margin of Error |
+|-------------|-------|-----------|----------------|---------------------|-----------------|
+| Forum | a | Pass | 89% | 5.3 | ±3% |
+| Chat | b | Pass | 84% | 4.7 | ±2% |
+| News | c | Pass | 90% | 5.3 | ±3% |
+| Onchain | d | Fail | 55% | 4.7 | ±2% |
+
 > **Prerequisite:** `data/input/PKD Governance Data.xlsx` must exist and include executed referenda (e.g., populate it via `python src/data_processing/referenda_updater.py`). Without this data the fallback accuracy report cannot be generated.
 
 ### 8. Draft Ranking & Workbook Storage

--- a/src/main.py
+++ b/src/main.py
@@ -81,7 +81,9 @@ def summarise_draft_predictions(
                 "predicted": predicted,
                 "confidence": confidence,
                 "prediction_time": draft.get("prediction_time", 0.0),
-                "margin_of_error": forecast.get("turnout_estimate", 0.0),
+                "margin_of_error": forecast.get(
+                    "margin_of_error", forecast.get("turnout_estimate", 0.0)
+                ),
             }
         )
     return records
@@ -422,7 +424,9 @@ def main() -> None:
     # Display summary tables (Tables 2-5)
     print_data_sources_table(stats.get("data_sources", {}))
     print_sentiment_embedding_table(stats.get("sentiment_batches", []))
-    print_draft_forecast_table(stats.get("draft_predictions", []))
+    print_draft_forecast_table(
+        stats.get("draft_predictions", []), MIN_PASS_CONFIDENCE
+    )
     print_prediction_accuracy_table(stats["prediction_eval"])
     print_timing_benchmarks_table(stats.get("timings", {}))
 

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -349,7 +349,9 @@ def print_sentiment_embedding_table(stats: Iterable[Mapping[str, Any]]) -> None:
     print(table)
 
 
-def print_draft_forecast_table(stats: Iterable[Mapping[str, Any]]) -> None:
+def print_draft_forecast_table(
+    stats: Iterable[Mapping[str, Any]], threshold: float
+) -> None:
     """Print a table of proposal draft outcome forecasts."""
 
     headers = [
@@ -363,14 +365,17 @@ def print_draft_forecast_table(stats: Iterable[Mapping[str, Any]]) -> None:
 
     rows = []
     for info in stats:
+        confidence = info.get("confidence", 0.0)
+        prediction_time = info.get("prediction_time", 0.0)
+        margin = info.get("margin_of_error", 0.0)
         rows.append(
             [
                 info.get("source", "-"),
                 info.get("title", "-"),
                 info.get("predicted", "-"),
-                f"{info.get('confidence', 0.0) * 100:.1f}",
-                f"{info.get('prediction_time', 0.0):.2f}",
-                f"{info.get('margin_of_error', 0.0):.2f}",
+                f"{confidence * 100:.0f}%",
+                f"{prediction_time:.1f}",
+                f"±{margin * 100:.0f}%",
             ]
         )
 
@@ -378,6 +383,9 @@ def print_draft_forecast_table(stats: Iterable[Mapping[str, Any]]) -> None:
         print("No draft predictions available")
         return
 
-    print("\nTable: Draft Outcome Forecasts")
+    print(
+        "\nTable: Drafted proposal success prediction and forecast "
+        f"(Pass confidence threshold <{threshold * 100:.0f}%)"
+    )
     table = _format_table(headers, rows)
     print(table)

--- a/tests/test_draft_forecast_table.py
+++ b/tests/test_draft_forecast_table.py
@@ -1,6 +1,7 @@
 import importlib
 
 from src import main
+from src.reporting.summary_tables import print_draft_forecast_table
 
 
 def test_drafts_under_threshold_label_fail(monkeypatch):
@@ -16,3 +17,22 @@ def test_drafts_under_threshold_label_fail(monkeypatch):
     ]
     records = main.summarise_draft_predictions(drafts, main.MIN_PASS_CONFIDENCE)
     assert records[0]["predicted"] == "Fail"
+
+
+def test_print_draft_forecast_table_output(capsys):
+    stats = [
+        {
+            "source": "Forum",
+            "title": "a",
+            "predicted": "Pass",
+            "confidence": 0.89,
+            "prediction_time": 5.3,
+            "margin_of_error": 0.03,
+        }
+    ]
+    print_draft_forecast_table(stats, 0.8)
+    out = capsys.readouterr().out
+    assert "Drafted proposal success prediction and forecast" in out
+    assert "Pass confidence threshold <80%" in out
+    assert "89%" in out
+    assert "±3%" in out


### PR DESCRIPTION
## Summary
- display pass-confidence draft forecast table with threshold and ±% formatting
- record margin-of-error in draft summaries
- test rendering of the forecast table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a06617e2dc8322a459ff5dbb45d07a