### PR TITLE
Fix duplicate news draft and load .env config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ telethon==1.40.0
 snscrape==0.7.0.20230622
 web3==7.13.0
 eth-account==0.13.7
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- load .env to honour MIN_PASS_CONFIDENCE setting
- avoid duplicate news predictions and add on-chain forecast draft
- include python-dotenv dependency
- move on-chain-only draft logic into reporting.summary_tables to keep main cleaner

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08366f62c83229da556e05a36b0a5