### PR TITLE
Normalize data source labels and compute news digest metrics

### DIFF
--- a/src/agents/data_collector.py
+++ b/src/agents/data_collector.py
@@ -45,10 +45,11 @@ class DataCollector:
         # Compute simple source statistics
         # ------------------------------------------------------------------
         update_freq = {
-            "chat": "realtime",
-            "forum": "daily",
-            "news": "hourly",
-            "chain": "≈6s",
+            "chat": "Real time",
+            "forum": "Daily",
+            "news": "Hourly",
+            "governance": "Every Run",
+            "chain": "~6 sec",
         }
         platform_map = {
             "chat": "X (@PolkadotNetwork), Reddit (r/Polkadot)",
@@ -94,9 +95,14 @@ class DataCollector:
         news = news_fn()
 
         news_count = len(news.get("digest", [])) if isinstance(news, dict) else 0
+        avg_news_words = (
+            sum(len(t.split()) for t in news.get("digest", [])) / news_count
+            if news_count
+            else 0.0
+        )
         stats["data_sources"]["news"] = {
             "count": news_count,
-            "avg_word_length": 0.0,
+            "avg_word_length": avg_news_words,
             "update_frequency": update_freq.get("news", "unknown"),
             "platform": platform_map.get("news"),
             "weight": weights.get("news", 1.0),
@@ -131,7 +137,7 @@ class DataCollector:
             {
                 "count": 0,
                 "avg_word_length": 0.0,
-                "update_frequency": "unknown",
+                "update_frequency": update_freq.get("governance", "unknown"),
                 "platform": None,
                 "weight": weights.get("governance", 1.0),
             },

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -62,17 +62,37 @@ def print_data_sources_table(stats: Mapping[str, Mapping[str, Any]]) -> None:
         "Source Type",
         "Platform/URL",
         "# Documents",
-        "Avg. Length",
+        "Avg. Length (words)",
         "Update Frequency",
         ]
+
+    source_map = {
+        "chat": "Community Chat",
+        "forum": "Forum",
+        "news": "News Blogs",
+        "governance": "Governance Docs",
+        "chain": "Voting Histories",
+    }
+    freq_map = {
+        "daily": "Daily",
+        "hourly": "Hourly",
+        "realtime": "Real time",
+        "real time": "Real time",
+        "every run": "Every Run",
+        "every_run": "Every Run",
+        "~6s": "~6 sec",
+        "~6 sec": "~6 sec",
+        "≈6s": "~6 sec",
+    }
 
     rows = []
     for source, info in stats.items():
         platform = info.get("platform") or info.get("url") or "-"
         count = info.get("count", 0)
-        avg_len = f"{info.get('avg_word_length', 0):.1f}"
-        freq = info.get("update_frequency", "-")
-        rows.append([source, platform, count, avg_len, freq])
+        avg_len = int(info.get("avg_word_length", 0) or 0)
+        freq_raw = str(info.get("update_frequency", "-"))
+        freq = freq_map.get(freq_raw.lower(), freq_raw)
+        rows.append([source_map.get(source, source), platform, count, avg_len, freq])
 
     if not rows:
         print("No data sources available")


### PR DESCRIPTION
## Summary
- Show human-friendly data source names and update frequencies in summary tables
- Compute average word length for news digests
- Display integer word counts with descriptive header

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a089b55fdc83228da36585a6e936c6