### PR TITLE
Filter draft forecasts by confidence and map sources

### DIFF
--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -385,14 +385,27 @@ def print_draft_forecast_table(
         "Margin of Error",
     ]
 
+    source_map = {
+        "forum": "Forum",
+        "chat": "Chat",
+        "news": "News",
+        "onchain": "Onchain",
+        "chain": "Onchain",
+        "governance": "Governance",
+    }
+
     rows = []
     for info in stats:
         confidence = info.get("confidence", 0.0)
+        if confidence >= threshold:
+            continue
         prediction_time = info.get("prediction_time", 0.0)
         margin = info.get("margin_of_error", 0.0)
+        source_key = str(info.get("source", "-"))
+        source = source_map.get(source_key.lower(), source_key)
         rows.append(
             [
-                info.get("source", "-"),
+                source,
                 info.get("title", "-"),
                 info.get("predicted", "-"),
                 f"{confidence * 100:.0f}%",

--- a/tests/test_draft_forecast_table.py
+++ b/tests/test_draft_forecast_table.py
@@ -22,17 +22,26 @@ def test_drafts_under_threshold_label_fail(monkeypatch):
 def test_print_draft_forecast_table_output(capsys):
     stats = [
         {
-            "source": "Forum",
+            "source": "forum",
             "title": "a",
             "predicted": "Pass",
-            "confidence": 0.89,
+            "confidence": 0.79,
             "prediction_time": 5.3,
             "margin_of_error": 0.03,
-        }
+        },
+        {
+            "source": "chat",
+            "title": "b",
+            "predicted": "Pass",
+            "confidence": 0.89,
+            "prediction_time": 4.2,
+            "margin_of_error": 0.05,
+        },
     ]
     print_draft_forecast_table(stats, 0.8)
     out = capsys.readouterr().out
     assert "Drafted proposal success prediction and forecast" in out
     assert "Pass confidence threshold <80%" in out
-    assert "89%" in out
+    assert "Forum" in out and "Chat" not in out
+    assert "79%" in out
     assert "±3%" in out


### PR DESCRIPTION
## Summary
- Only display draft forecasts whose confidence is below the pass threshold
- Map raw source keys to user-friendly labels like Forum or Chat
- Test coverage for filtering and source mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a08bce29c88322826a2e66f7c58e2e