### PR TITLE
Use human-readable labels for timing benchmarks

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -404,13 +404,13 @@ def main() -> None:
 
     proposals_processed = max(1, len(stats.get("prediction_eval", [])))
     if proposals_processed < 5:
-        scenario = "light"
+        scenario_label = "Light Load"
     elif proposals_processed < 20:
-        scenario = "medium"
+        scenario_label = "Medium Load"
     else:
-        scenario = "high"
+        scenario_label = "High Load"
     stats["timings"] = {
-        scenario: {
+        scenario_label: {
             "proposals": proposals_processed,
             **phase_times,
         }
@@ -421,7 +421,9 @@ def main() -> None:
         existing = (
             json.loads(timings_path.read_text()) if timings_path.exists() else {}
         )
-        existing.setdefault(scenario, []).append(stats["timings"][scenario])
+        existing.setdefault(scenario_label, []).append(
+            stats["timings"][scenario_label]
+        )
         timings_path.write_text(json.dumps(existing, indent=2))
     except Exception:
         pass

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -122,11 +122,21 @@ def print_timing_benchmarks_table(stats: Mapping[str, Any]) -> None:
         "Ingestion (s)",
         "Analysis + Prediction (s)",
         "Draft + Sign (s)",
-        "Total (s)",
+        "Total Time (s)",
     ]
+
+    scenario_labels = {
+        "light": "Light Load",
+        "light load": "Light Load",
+        "medium": "Medium Load",
+        "medium load": "Medium Load",
+        "high": "High Load",
+        "high load": "High Load",
+    }
 
     rows = []
     for scenario, info in stats.items():
+        scenario_display = scenario_labels.get(str(scenario).lower(), scenario)
         if not isinstance(info, Mapping):
             # If a list of runs is provided, aggregate by averaging
             runs = list(info)
@@ -147,7 +157,7 @@ def print_timing_benchmarks_table(stats: Mapping[str, Any]) -> None:
         total = ingestion + analysis + draft
         rows.append(
             [
-                scenario,
+                scenario_display,
                 f"{proposals:.0f}",
                 f"{ingestion:.2f}",
                 f"{analysis:.2f}",


### PR DESCRIPTION
## Summary
- Rename timing summary column to `Total Time (s)` for clarity.
- Display friendly scenario labels (Light/Medium/High Load) when printing timing tables.
- Record timing benchmarks under human-readable scenario keys.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09000038083228504ebcae9905485