### PR TITLE
Ensure CTX/KB terminology is uppercase in sentiment table docs

### DIFF
--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -366,8 +366,9 @@ def print_sentiment_embedding_table(stats: Iterable[Mapping[str, Any]]) -> None:
     ----------
     stats:
         Iterable of dictionaries each describing one sentiment analysis batch
-        with the keys ``batch_id``, ``ctx_size_kb``, ``sentiment``,
-        ``confidence`` and ``embedded``.
+        with the keys ``batch_id``, ``ctx_size_kb`` (CTX size in KB),
+        ``sentiment``, ``confidence`` and ``embedded`` specifying if the batch
+        was stored in the KB.
     """
 
     headers = [


### PR DESCRIPTION
## Summary
- Clarify sentiment table docs to use uppercase CTX and KB terminology

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a090f4e1a48322a422ac94e08b1dc7