### PR TITLE
Persist timing history and refactor main helpers

### DIFF
--- a/src/execution/broadcast.py
+++ b/src/execution/broadcast.py
@@ -1,0 +1,21 @@
+"""Utility to broadcast proposals to community platforms."""
+from __future__ import annotations
+
+from .discord_bot import post_summary as post_discord
+from .telegram_bot import post_summary as post_telegram
+from .twitter_bot import post_summary as post_twitter
+
+
+def broadcast_proposal(text: str) -> None:
+    """Send ``text`` to any configured community platforms."""
+    sent = []
+    if post_discord(text):
+        sent.append("Discord")
+    if post_telegram(text):
+        sent.append("Telegram")
+    if post_twitter(text):
+        sent.append("Twitter")
+    if sent:
+        print("📢 Broadcasted proposal to " + ", ".join(sent))
+    else:
+        print("⚠️ No community platforms configured")

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -69,6 +69,18 @@ def abbrev_number(value: float, suffix: str = "") -> str:
 
 
 # ────────────────────────────────────────────────────────────────────────────
+# 4. Markdown helpers
+# ────────────────────────────────────────────────────────────────────────────
+def extract_first_heading(text: str) -> str:
+    """Return the first markdown heading found in ``text``."""
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("#"):
+            return line.lstrip("#").strip()
+    return text.splitlines()[0].strip() if text else ""
+
+
+# ────────────────────────────────────────────────────────────────────────────
 # Stand-alone smoke test
 # ────────────────────────────────────────────────────────────────────────────
 if __name__ == "__main__":

--- a/tests/test_draft_forecast_table.py
+++ b/tests/test_draft_forecast_table.py
@@ -1,7 +1,10 @@
 import importlib
 
 from src import main
-from src.reporting.summary_tables import print_draft_forecast_table
+from src.reporting.summary_tables import (
+    print_draft_forecast_table,
+    summarise_draft_predictions,
+)
 
 
 def test_drafts_under_threshold_label_fail(monkeypatch):
@@ -15,7 +18,7 @@ def test_drafts_under_threshold_label_fail(monkeypatch):
             "prediction_time": 0.01,
         }
     ]
-    records = main.summarise_draft_predictions(drafts, main.MIN_PASS_CONFIDENCE)
+    records = summarise_draft_predictions(drafts, main.MIN_PASS_CONFIDENCE)
     assert records[0]["predicted"] == "Fail"
 
 


### PR DESCRIPTION
## Summary
- Track timing metrics across executions and display last three runs in benchmarks table
- Move proposal broadcasting and markdown heading extraction into dedicated modules
- Expose draft prediction summariser for reuse outside `main`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a086f0e3b483229761842c16a89b77