### PR TITLE
Randomize historical prediction sampling

### DIFF
--- a/.env
+++ b/.env
@@ -16,9 +16,9 @@
  DATA_WEIGHT_CHAIN=0.20        # on-chain metrics
  DATA_WEIGHT_GOVERNANCE=0.15   # past governance data
 
- # Recency controls
- NEWS_LOOKBACK_DAYS=3          # days of news to fetch
- # Fallback historical evaluation
- HISTORICAL_SAMPLE_SEED=0      # optional seed for sampling historical referenda
- # Minimum confidence to label a draft as passing
- MIN_PASS_CONFIDENCE=0.50
+# Recency controls
+NEWS_LOOKBACK_DAYS=3          # days of news to fetch
+# Fallback historical evaluation
+# HISTORICAL_SAMPLE_SEED=1      # optional seed for sampling historical referenda
+# Minimum confidence to label a draft as passing
+MIN_PASS_CONFIDENCE=0.50

--- a/README.md
+++ b/README.md
@@ -206,10 +206,10 @@ Create a `.env` file in the project root:
 
  # Recency controls
  NEWS_LOOKBACK_DAYS=3          # days of news to fetch
- # Fallback historical evaluation
- HISTORICAL_SAMPLE_SEED=0      # optional seed for sampling historical referenda
- # Minimum confidence to label a draft as passing
- MIN_PASS_CONFIDENCE=0.80
+# Fallback historical evaluation
+# HISTORICAL_SAMPLE_SEED=1      # optional seed for sampling historical referenda
+# Minimum confidence to label a draft as passing
+MIN_PASS_CONFIDENCE=0.80
 ```
 
 `SUBSTRATE_NODE_URL` should point to a Substrate RPC endpoint. Common choices
@@ -221,10 +221,11 @@ Telegram, and Twitter variables enable posting proposal summaries to those
 platforms via the execution layer connectors.
 
 `NEWS_LOOKBACK_DAYS` controls the number of past days of RSS items retrieved by
-the news fetcher. `HISTORICAL_SAMPLE_SEED` can be set to an integer to make
-historical prediction sampling reproducible; omit it to allow nondeterministic
-selection. `MIN_PASS_CONFIDENCE` defines the approval probability threshold used
-to label draft proposals as "Pass" in the forecast summary table.
+the news fetcher. `HISTORICAL_SAMPLE_SEED` can be set to a **non-zero** integer
+to make historical prediction sampling reproducible; omit it or set it to `0`
+to allow nondeterministic selection. `MIN_PASS_CONFIDENCE` defines the approval
+probability threshold used to label draft proposals as "Pass" in the forecast
+summary table.
 
 #### Data Weighting System
 

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -229,7 +229,9 @@ def evaluate_historical_predictions(sample_size: int = 5) -> list[dict[str, Any]
     sample_kwargs = {"n": min(sample_size, len(df_done))}
     if seed:
         try:
-            sample_kwargs["random_state"] = int(seed)
+            seed_val = int(seed)
+            if seed_val != 0:
+                sample_kwargs["random_state"] = seed_val
         except ValueError:
             pass
 

--- a/tests/test_historical_prediction_fallback.py
+++ b/tests/test_historical_prediction_fallback.py
@@ -21,7 +21,7 @@ def test_historical_prediction_fallback(monkeypatch):
     )
 
     # Ensure deterministic sampling
-    monkeypatch.setenv("HISTORICAL_SAMPLE_SEED", "0")
+    monkeypatch.setenv("HISTORICAL_SAMPLE_SEED", "42")
 
     results = evaluate_historical_predictions(sample_size=5)
 
@@ -29,7 +29,7 @@ def test_historical_prediction_fallback(monkeypatch):
     assert len(results) == 3
 
     # Sample order should be deterministic due to seed
-    assert [r["Proposal ID"] for r in results] == [3, 2, 1]
+    assert [r["Proposal ID"] for r in results] == [1, 2, 3]
 
     for res in results:
         assert res.get("Predicted")


### PR DESCRIPTION
## Summary
- Skip seeding historical referenda sampling when `HISTORICAL_SAMPLE_SEED` is `0` or unset so proposal IDs vary across runs
- Document how to enable deterministic sampling with a non-zero seed
- Update fallback test to use explicit seed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e4d20264832293ae42282ea8295a