### PR TITLE
Fix draft forecast table filtering for failing proposals

### DIFF
--- a/data/output/referenda_failures.csv
+++ b/data/output/referenda_failures.csv
@@ -159,3 +159,8 @@ Referendum_ID,error,missing_info,function,time
 1723,incomplete data after fallback,"Start, End, Status",collect_referendum,2025-08-21T08:30:14Z
 1724,incomplete data after fallback,"Start, End, Status",collect_referendum,2025-08-21T08:30:18Z
 1725,incomplete data after fallback,"Start, End, Status",collect_referendum,2025-08-21T08:30:21Z
+2,incomplete data after fallback,"Start, End, Status",collect_referendum,2025-08-21T10:12:16Z
+3,incomplete data after fallback,"Start, End, Status",collect_referendum,2025-08-21T10:12:17Z
+4,incomplete data after fallback,"Start, End, Status",collect_referendum,2025-08-21T10:12:17Z
+5,incomplete data after fallback,"Start, End, Status",collect_referendum,2025-08-21T10:12:17Z
+6,incomplete data after fallback,"Start, End, Status",collect_referendum,2025-08-21T10:12:17Z

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -411,7 +411,8 @@ def print_draft_forecast_table(
     rows = []
     for info in stats:
         confidence = info.get("confidence", 0.0)
-        if confidence >= threshold:
+        predicted = str(info.get("predicted", ""))
+        if predicted.lower() == "pass" and confidence >= threshold:
             continue
         prediction_time = info.get("prediction_time", 0.0)
         margin = info.get("margin_of_error", 0.0)
@@ -481,8 +482,9 @@ def summarise_draft_predictions(
     records: list[dict[str, Any]] = []
     for draft in drafts:
         forecast = draft.get("forecast", {})
-        confidence = forecast.get("approval_prob", 0.0)
-        predicted = "Pass" if confidence >= threshold else "Fail"
+        approval_prob = forecast.get("approval_prob", 0.0)
+        predicted = "Pass" if approval_prob >= threshold else "Fail"
+        confidence = approval_prob if predicted == "Pass" else 1 - approval_prob
         records.append(
             {
                 "source": draft.get("source", ""),

--- a/tests/test_draft_forecast_table.py
+++ b/tests/test_draft_forecast_table.py
@@ -14,12 +14,13 @@ def test_drafts_under_threshold_label_fail(monkeypatch):
         {
             "source": "chat",
             "text": "# Title\nBody",
-            "forecast": {"approval_prob": 0.5, "turnout_estimate": 0.1},
+            "forecast": {"approval_prob": 0.2, "turnout_estimate": 0.1},
             "prediction_time": 0.01,
         }
     ]
     records = summarise_draft_predictions(drafts, main.MIN_PASS_CONFIDENCE)
     assert records[0]["predicted"] == "Fail"
+    assert abs(records[0]["confidence"] - 0.8) < 1e-9
 
 
 def test_print_draft_forecast_table_output(capsys):
@@ -56,3 +57,20 @@ def test_print_draft_forecast_table_output(capsys):
     assert "Forum" in out and "Onchain" in out and "Chat" not in out
     assert "79%" in out
     assert "±3%" in out
+
+
+def test_print_draft_forecast_table_includes_fail_high_confidence(capsys):
+    stats = [
+        {
+            "source": "forum",
+            "title": "a",
+            "predicted": "Fail",
+            "confidence": 0.95,
+            "prediction_time": 1.0,
+            "margin_of_error": 0.02,
+        }
+    ]
+    print_draft_forecast_table(stats, 0.8)
+    out = capsys.readouterr().out
+    assert "forum".capitalize() in out  # source is shown
+    assert "95%" in out


### PR DESCRIPTION
## Summary
- Show draft prediction rows for failing proposals even when confidence exceeds pass threshold
- Compute confidence as the probability of the predicted outcome
- Add regression tests covering high-confidence failure predictions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6f01cb9888322a0ab95929388b76f