### PR TITLE
Include governance document metrics in data source stats

### DIFF
--- a/tests/test_data_collector_governance_stats.py
+++ b/tests/test_data_collector_governance_stats.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from agents.data_collector import DataCollector
+from agents import data_collector
+
+
+def test_governance_stats(monkeypatch, tmp_path):
+    df = pd.DataFrame({"a": ["hello world", "foo bar"]})
+    fake_path = tmp_path / "dummy.xlsx"
+    fake_path.touch()
+    monkeypatch.setattr(data_collector, "ROOT", tmp_path)
+    monkeypatch.setattr(data_collector, "XLSX_PATH", fake_path)
+    monkeypatch.setattr(data_collector.pd, "read_excel", lambda *args, **kwargs: {"Context": df})
+    data = DataCollector.collect(msg_fn=lambda: {}, news_fn=lambda: {}, block_fn=lambda: [])
+    gov = data["stats"]["data_sources"]["governance"]
+    assert gov["count"] == 2
+    assert gov["avg_word_length"] == 2.0
+    assert gov["total_tokens"] == 4


### PR DESCRIPTION
## Summary
- calculate count, average length, and token volume for governance documents by parsing the governance workbook
- add unit test for governance statistics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae801a96788322b29ef81b40029ca9