### PR TITLE
Improve social media scraper quick test output

### DIFF
--- a/src/data_processing/social_media_scraper.py
+++ b/src/data_processing/social_media_scraper.py
@@ -415,6 +415,8 @@ def collect_recent_messages() -> Dict[str, List[Any]]:
 
 # Stand-alone quick test ------------------------------------------------------
 if __name__ == "__main__":
-    data = collect_recent_messages()
-    print(f"Collected {len(data)} messages.")
-    print(data[:10])
+    grouped = collect_recent_messages()
+    total = sum(len(v) for v in grouped.values())
+    print(f"Collected {total} messages.")
+    for source, msgs in grouped.items():
+        print(source, msgs[:3])


### PR DESCRIPTION
## Summary
- enhance standalone quick test for `collect_recent_messages` with per-source preview

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b726ec5bd0832286217ae3c5c41cf6