### PR TITLE
Parse forum post HTML before flattening

### DIFF
--- a/src/data_processing/social_media_scraper.py
+++ b/src/data_processing/social_media_scraper.py
@@ -114,13 +114,19 @@ def _simple_post(post: dict) -> dict:
 
 def flatten_forum_topic(topic: dict) -> str:
     """Combine title, body and comments into a single text blob."""
-    parts: list[str] = [topic.get("title", "")]
+
+    def _extract_text(fragment: Any) -> str:
+        if not isinstance(fragment, str):
+            return ""
+        return _clean(BeautifulSoup(fragment, "html.parser").get_text(" ", strip=True))
+
+    parts: list[str] = [_extract_text(topic.get("title", ""))]
     details = topic.get("details", {})
     if isinstance(details, dict):
-        parts.append(details.get("content", ""))
+        parts.append(_extract_text(details.get("content", "")))
     for c in topic.get("comments_replies", []):
         if isinstance(c, dict):
-            parts.append(c.get("content", ""))
+            parts.append(_extract_text(c.get("content", "")))
     return _clean(" ".join(p for p in parts if p))
 
 


### PR DESCRIPTION
## Summary
- strip HTML from forum titles, bodies, and comments with BeautifulSoup when flattening topics
- ensure clean text by applying `_clean` to each segment and the final joined string

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b728fc7dac8322afd1a4c6eb73ae5c