### PR TITLE
Handle missing Ollama server gracefully

### DIFF
--- a/src/llm/ollama_api.py
+++ b/src/llm/ollama_api.py
@@ -32,21 +32,21 @@ class OllamaError(RuntimeError):
     """Raised when the Ollama server returns a non‑200 or malformed response."""
 
 
-# def _post(url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-#     """Internal helper with basic error handling."""
-#     try:
-#         resp = requests.post(url, json=payload, timeout=240)
-#         resp.raise_for_status()
-#         return resp.json()
-#     except Exception as exc:  # noqa: BLE001
-#         raise OllamaError(f"Ollama request failed: {exc}") from exc
+def _post(url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Internal helper with basic error handling.
 
-def _post(url, payload):
-    resp = requests.post(url, json=payload, timeout=240)
-    if resp.status_code != 200:
-        detail = resp.json().get("error", resp.text)
-        raise OllamaError(f"{resp.status_code} – {detail} – model asked: {payload.get('model')}")
-    return resp.json()
+    This wraps :func:`requests.post` so that network issues or non-2xx responses
+    raise :class:`OllamaError` with a helpful message.  The previous
+    implementation surfaced raw ``requests`` exceptions which bubbled up and
+    crashed the application when the local Ollama server was not running.
+    """
+
+    try:
+        resp = requests.post(url, json=payload, timeout=240)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # noqa: BLE001
+        raise OllamaError(f"Ollama request failed: {exc}") from exc
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Wrap Ollama HTTP calls with error handling and raise `OllamaError` on failures
- Catch `OllamaError` in news summariser to return a fallback message instead of crashing

## Testing
- `pytest -q`
- `python - <<'PY'
import sys
sys.path.append('src')
from data_processing.news_fetcher import fetch_and_summarise_news
print(fetch_and_summarise_news())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b7360938088322a000ca5db4db3a2c