### PR TITLE
feat: configure LLM token and temperature settings

### DIFF
--- a/src/agents/proposal_generator.py
+++ b/src/agents/proposal_generator.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Dict, Any
 
 from llm import ollama_api
@@ -22,13 +23,32 @@ def build_prompt(context: Dict[str, Any]) -> str:
     )
 
 
-def draft(context_dict: Dict[str, Any]) -> str:
-    """Return a proposal generated from ``context_dict``."""
+def draft(
+    context_dict: Dict[str, Any],
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+) -> str:
+    """Return a proposal generated from ``context_dict``.
+
+    ``temperature`` and ``max_tokens`` default to the environment variables
+    ``PROPOSAL_TEMPERATURE`` and ``PROPOSAL_MAX_TOKENS`` (falling back to 0.3 and
+    4096 respectively).
+    """
+    temperature = (
+        temperature
+        if temperature is not None
+        else float(os.getenv("PROPOSAL_TEMPERATURE", "0.3"))
+    )
+    max_tokens = (
+        max_tokens
+        if max_tokens is not None
+        else int(os.getenv("PROPOSAL_MAX_TOKENS", "4096"))
+    )
     prompt = build_prompt(context_dict)
     return ollama_api.generate_completion(
         prompt=prompt,
         system="You are Polkadot-Gov-Agent v1.",
         model="gemma3:4b",
-        temperature=0.3,
-        max_tokens=4096,
+        temperature=temperature,
+        max_tokens=max_tokens,
     )

--- a/src/analysis/sentiment_analysis.py
+++ b/src/analysis/sentiment_analysis.py
@@ -12,6 +12,12 @@ from agents.sentiment_analyser import (
 __all__ = ["analyse_messages", "_extract_json", "simple_polarity"]
 
 
-def analyse_messages(messages: Iterable[str]) -> Dict[str, Any]:
-    """Delegate to :func:`agents.sentiment_analyser.analyse_messages`."""
-    return _analyse_messages(messages)
+def analyse_messages(
+    messages: Iterable[str],
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+) -> Dict[str, Any]:
+    """Delegate to :func:`agents.sentiment_analyser.analyse_messages` with optional parameters."""
+    return _analyse_messages(
+        messages, temperature=temperature, max_tokens=max_tokens
+    )


### PR DESCRIPTION
## Summary
- make sentiment analysis configurable via SENTIMENT_TEMPERATURE and SENTIMENT_MAX_TOKENS
- allow proposal drafts to override LLM temperature and max tokens
- expose NEWS_TEMPERATURE and NEWS_MAX_TOKENS for news summarisation and forward all LLM settings from main pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b746f6c5208322acc6b2449348c2e5