### PR TITLE
Add unit tests for analysis metrics and Ollama API wrapper

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,1 +1,67 @@
- 
+import datetime as dt
+
+import pytest
+
+from analysis import blockchain_metrics, news_analysis
+
+
+def test_summarise_blocks_empty_returns_defaults():
+    assert blockchain_metrics.summarise_blocks([]) == {
+        "daily_tx_count": {},
+        "daily_total_fees_DOT": {},
+        "avg_tx_per_block": 0,
+        "avg_fee_per_tx_DOT": 0,
+        "busiest_hour_utc": "",
+    }
+
+
+def test_summarise_blocks_computes_metrics():
+    base = dt.datetime(2024, 1, 1, tzinfo=dt.UTC)
+    blocks = [
+        {
+            "block_timestamp": int(base.timestamp()),
+            "extrinsics_count": 10,
+            "total_fee": 2 * 10**10,
+        },
+        {
+            "block_timestamp": int((base + dt.timedelta(hours=1)).timestamp()),
+            "extrinsics_count": 20,
+            "total_fee": 4 * 10**10,
+        },
+        {
+            "block_timestamp": int((base + dt.timedelta(days=1)).timestamp()),
+            "extrinsics_count": 5,
+            "total_fee": 1 * 10**10,
+        },
+    ]
+    result = blockchain_metrics.summarise_blocks(blocks)
+    assert result["daily_tx_count"] == {"2024-01-01": 30, "2024-01-02": 5}
+    assert result["daily_total_fees_DOT"] == {"2024-01-01": 6.0, "2024-01-02": 1.0}
+    assert result["avg_tx_per_block"] == pytest.approx(11.67, rel=1e-2)
+    assert result["avg_fee_per_tx_DOT"] == pytest.approx(0.2, rel=1e-6)
+    assert result["busiest_hour_utc"] == "2024-01-01 01:00"
+
+
+def test_summarise_news_handles_empty():
+    assert news_analysis.summarise_news([]) == {
+        "digest": [],
+        "risks": "No recent Polkadot news in the last 3 days.",
+    }
+
+
+def test_summarise_news_parses_llm_output(monkeypatch):
+    called = {}
+
+    def fake_generate(prompt, system, temperature, max_tokens, model):
+        called["prompt"] = prompt
+        called["system"] = system
+        return '{"digest":["one"],"risks":"two"}'
+
+    monkeypatch.setattr(news_analysis, "generate_completion", fake_generate)
+
+    items = [{"title": "T1", "summary": "S1"}]
+    result = news_analysis.summarise_news(items)
+
+    assert result == {"digest": ["one"], "risks": "two"}
+    assert "T1" in called["prompt"] and "S1" in called["prompt"]
+    assert called["system"] == news_analysis.SYSTEM_PROMPT

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,1 +1,47 @@
- 
+import pytest
+
+from llm import ollama_api
+
+
+def test_post_raises_ollama_error(monkeypatch):
+    def fake_post(url, json=None, timeout=None):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(ollama_api.requests, "post", fake_post)
+    with pytest.raises(ollama_api.OllamaError):
+        ollama_api._post("http://test", {})
+
+
+def test_generate_completion_builds_payload(monkeypatch):
+    captured = {}
+
+    def fake_post(url, payload):
+        captured["url"] = url
+        captured["payload"] = payload
+        return {"response": "answer  "}
+
+    monkeypatch.setattr(ollama_api, "_post", fake_post)
+
+    res = ollama_api.generate_completion(
+        "Q", model="m", system="sys", temperature=0.5, max_tokens=10
+    )
+    assert res == "answer"
+    assert captured["url"] == ollama_api.GENERATE_URL
+    payload = captured["payload"]
+    assert payload["model"] == "m"
+    assert payload["options"]["temperature"] == 0.5
+    assert payload["options"]["num_predict"] == 10
+    assert payload["stream"] is False
+    assert payload["prompt"].startswith("<|system|>")
+    assert "Q" in payload["prompt"]
+
+
+def test_embed_text_uses_post(monkeypatch):
+    def fake_post(url, payload):
+        assert url == ollama_api.EMBED_URL
+        assert payload == {"model": "m", "prompt": "text"}
+        return {"embedding": [0.1, 0.2]}
+
+    monkeypatch.setattr(ollama_api, "_post", fake_post)
+    emb = ollama_api.embed_text("text", model="m")
+    assert emb == [0.1, 0.2]


### PR DESCRIPTION
## Summary
- test blockchain metrics summarisation and news analysis JSON parsing
- test Ollama API helper functions for error handling and payload correctness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7b41822048322bb616eb786f2d7b6