### PR TITLE
Add EVM block metrics and context integration

### DIFF
--- a/src/agents/context_generator.py
+++ b/src/agents/context_generator.py
@@ -116,6 +116,7 @@ def build_context(
     news: Dict[str, Any],
     chain_kpis: Dict[str, Any],
     gov_kpis: Dict[str, Any],
+    evm_kpis: Dict[str, Any] | None = None,
     kb_snippets: list[str] | None = None,
     kb_query: str | None = None,
     *,
@@ -143,10 +144,12 @@ def build_context(
     news_w = _env_weight("DATA_WEIGHT_NEWS")
     chain_w = _env_weight("DATA_WEIGHT_CHAIN")
     gov_w = _env_weight("DATA_WEIGHT_GOVERNANCE")
+    evm_w = _env_weight("DATA_WEIGHT_EVM")
 
     weighted_sentiment = _apply_weight(sentiment, sentiment_w)
     weighted_news = _apply_weight(news, news_w)
     weighted_chain = _apply_weight(chain_kpis, chain_w)
+    weighted_evm = _apply_weight(evm_kpis or {}, evm_w)
     weighted_gov = _apply_weight(gov_kpis, gov_w)
 
     context = {
@@ -154,6 +157,7 @@ def build_context(
         "sentiment": weighted_sentiment,
         "news": weighted_news,
         "chain_kpis": weighted_chain,
+        "evm_kpis": weighted_evm,
         "governance_kpis": weighted_gov,
         "trending_topics": trending_topics or [],
         "kb_snippets": snippets,

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -108,6 +108,7 @@ def print_data_sources_table(stats: Mapping[str, Mapping[str, Any]]) -> None:
         "news": "News Blogs",
         "governance": "Governance Docs",
         "chain": "Voting Histories",
+        "evm_chain": "EVM Blocks",
     }
     freq_map = {
         "daily": "Daily",
@@ -563,6 +564,7 @@ def draft_onchain_proposal(
     chain_res: Mapping[str, Any],
     chain_kpis: Mapping[str, Any],
     gov_kpis: Mapping[str, Any],
+    evm_kpis: Mapping[str, Any] | None,
     query: str,
     trending_topics: list[str] | None = None,
 ) -> dict[str, Any] | None:
@@ -576,6 +578,7 @@ def draft_onchain_proposal(
         {},
         chain_kpis,
         gov_kpis,
+        evm_kpis,
         kb_query=query,
         trending_topics=trending_topics,
         summarise_snippets=True,

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -75,3 +75,18 @@ def validate_governance_kpis(d: Dict[str, Any]) -> bool:
     _require_keys(d, expected, "governance_kpis")
     return True
 
+
+def validate_evm_kpis(d: Dict[str, Any]) -> bool:
+    _require_keys(
+        d,
+        {
+            "daily_tx_count",
+            "daily_total_value_ETH",
+            "avg_tx_per_block",
+            "avg_value_per_tx_ETH",
+            "busiest_hour_utc",
+        },
+        "evm_kpis",
+    )
+    return True
+

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -28,7 +28,7 @@ def test_main_records_final_status(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
     captured_kb = {}
 
-    def fake_build_context(sentiment, news, chain, gov, kb_snippets=None, kb_query=None, **_):
+    def fake_build_context(sentiment, news, chain, gov, evm=None, kb_snippets=None, kb_query=None, **_):
         captured_kb["query"] = kb_query
         return {}
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -27,6 +27,13 @@ def test_validators_pass_on_dummy():
         "avg_fee_per_tx_DOT": 0,
         "busiest_hour_utc": "",
     }
+    evm = {
+        "daily_tx_count": {},
+        "daily_total_value_ETH": {},
+        "avg_tx_per_block": 0,
+        "avg_value_per_tx_ETH": 0,
+        "busiest_hour_utc": "",
+    }
     gov = {
         "total_referenda": 1,
         "executed_pct": 50,
@@ -42,6 +49,7 @@ def test_validators_pass_on_dummy():
     assert v.validate_news(news)
     assert v.validate_chain_kpis(chain)
     assert v.validate_governance_kpis(gov)
+    assert v.validate_evm_kpis(evm)
 
 
 def test_stored_proposals_influence_context(tmp_path, monkeypatch):
@@ -63,5 +71,5 @@ def test_stored_proposals_influence_context(tmp_path, monkeypatch):
     monkeypatch.setattr(ollama_api, "embed_text", fake_embed)
     monkeypatch.setattr(proposal_store, "record_context", lambda _c: None)
 
-    ctx = build_context({}, {}, {}, {}, kb_query="staking")
+    ctx = build_context({}, {}, {}, {}, {}, kb_query="staking")
     assert any("Increase staking rewards" in s for s in ctx["kb_snippets"])


### PR DESCRIPTION
## Summary
- Extend data collector to gather optional EVM chain blocks and include basic stats
- Add `summarise_evm_blocks` for EVM metrics and surface KPIs in generated context
- Update reporting and validators for new EVM metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7b59df47c83229ca2b17cced687eb