### PR TITLE
Rename chain stats to onchain and drop EVM metrics

### DIFF
--- a/src/agents/data_collector.py
+++ b/src/agents/data_collector.py
@@ -64,8 +64,7 @@ class DataCollector:
             "forum": "Daily",
             "news": "Hourly",
             "governance": "Every Run",
-            "chain": "~6 sec",
-            "evm_chain": "~12 sec",
+            "onchain": "~6 sec",
         }
         platform_map = {
             "chat": "X (@PolkadotNetwork), Reddit (r/Polkadot)",
@@ -89,8 +88,7 @@ class DataCollector:
             "chat": _env_weight("DATA_WEIGHT_CHAT"),
             "forum": _env_weight("DATA_WEIGHT_FORUM"),
             "news": _env_weight("DATA_WEIGHT_NEWS"),
-            "chain": _env_weight("DATA_WEIGHT_CHAIN"),
-            "evm_chain": _env_weight("DATA_WEIGHT_EVM"),
+            "onchain": _env_weight("DATA_WEIGHT_CHAIN"),
             "governance": _env_weight("DATA_WEIGHT_GOVERNANCE"),
         }
 
@@ -186,13 +184,13 @@ class DataCollector:
                 day = dt.datetime.fromtimestamp(ts, dt.UTC).date().isoformat()
                 if day in last3:
                     last3[day] += 1
-        stats["data_sources"]["chain"] = {
+        stats["data_sources"]["onchain"] = {
             "count": block_count,
             "avg_word_length": avg_extrinsics,
             "total_tokens": total_extrinsics,
-            "update_frequency": update_freq.get("chain", "unknown"),
+            "update_frequency": update_freq.get("onchain", "unknown"),
             "platform": rpc_url,
-            "weight": weights.get("chain", 1.0),
+            "weight": weights.get("onchain", 1.0),
             "rpc_url": rpc_url,
             "doc_url": doc_url,
             "last_3d_count": last3,
@@ -270,34 +268,6 @@ class DataCollector:
             print("🔄 Fetching EVM chain data …")
             evm_blocks = evm_fn()
             result["evm_blocks"] = evm_blocks
-
-            evm_block_count = len(evm_blocks)
-            tx_counts = [len(b.get("transactions", [])) for b in evm_blocks]
-            total_txs = sum(tx_counts)
-            avg_txs = total_txs / evm_block_count if evm_block_count else 0.0
-            evm_rpc = os.getenv("EVM_RPC_URL", "http://localhost:8545")
-            evm_doc = os.getenv(
-                "EVM_CHAIN_DOC_URL", "https://ethereum.org/en/developers/docs/"
-            )
-            last3 = {
-                (dt.date.today() - dt.timedelta(days=i)).isoformat(): 0 for i in range(3)
-            }
-            for blk in evm_blocks:
-                ts = blk.get("timestamp")
-                if ts:
-                    day = dt.datetime.fromtimestamp(ts, dt.UTC).date().isoformat()
-                    if day in last3:
-                        last3[day] += 1
-            stats["data_sources"]["evm_chain"] = {
-                "count": evm_block_count,
-                "avg_word_length": avg_txs,
-                "total_tokens": total_txs,
-                "update_frequency": update_freq.get("evm_chain", "unknown"),
-                "platform": evm_rpc,
-                "weight": weights.get("evm_chain", 1.0),
-                "rpc_url": evm_rpc,
-                "doc_url": evm_doc,
-                "last_3d_count": last3,
-            }
+            # EVM statistics are collected but not added to final stats dictionary
 
         return result

--- a/src/main.py
+++ b/src/main.py
@@ -183,7 +183,7 @@ def main() -> None:
     stats["sentiment_batches"].append(
         {
             "batch_id": batch_id,
-            "source": "chain",
+            "source": "onchain",
             "ctx_size_kb": chain_ctx_size,
             "sentiment": chain_res.get("sentiment", ""),
             "confidence": chain_res.get("confidence", 0.0),

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -85,18 +85,15 @@ def print_data_sources_table(stats: Mapping[str, Mapping[str, Any]]) -> None:
         Mapping of source type to a dictionary containing at least the keys
         ``count``, ``avg_word_length`` and ``update_frequency``. Optional keys
         ``rpc_url``/``platform`` or ``url`` may be supplied for display under the
-        ``RPC/URL`` column, ``doc_url`` for the ``Doc`` column and
-        ``last_3d_count`` for the recent per-day counts. ``total_tokens`` may be
-        provided; when absent it is estimated as ``count * avg_word_length``.
-        Missing values are represented by ``-``.
+        ``RPC/URL`` column. ``total_tokens`` may be provided; when absent it is
+        estimated as ``count * avg_word_length``. Missing values are represented
+        by ``-``.
     """
 
     headers = [
         "Source Type",
         "RPC/URL",
-        "Doc",
         "# Documents",
-        "Last 3 Days",
         "Avg. Length (words)",
         "Total token (Data volume)",
         "Update Frequency",
@@ -107,8 +104,7 @@ def print_data_sources_table(stats: Mapping[str, Mapping[str, Any]]) -> None:
         "forum": "Forum",
         "news": "News Blogs",
         "governance": "Governance Docs",
-        "chain": "Voting Histories",
-        "evm_chain": "EVM Blocks",
+        "onchain": "On-chain",
     }
     freq_map = {
         "daily": "Daily",
@@ -124,22 +120,15 @@ def print_data_sources_table(stats: Mapping[str, Mapping[str, Any]]) -> None:
 
     rows = []
     for source, info in stats.items():
+        if source == "evm_chain":
+            continue
         rpc_url = (
             info.get("rpc_url")
             or info.get("platform")
             or info.get("url")
             or "-"
         )
-        doc = info.get("doc_url", "-")
         count = info.get("count", 0)
-        last3_raw = info.get("last_3d_count")
-        if isinstance(last3_raw, dict):
-            dates = [
-                (dt.date.today() - dt.timedelta(days=i)).isoformat() for i in range(3)
-            ]
-            last3_str = ", ".join(str(int(last3_raw.get(d, 0))) for d in dates)
-        else:
-            last3_str = "-"
         avg_len = int(info.get("avg_word_length", 0) or 0)
         total = int(info.get("total_tokens") or count * avg_len)
         freq_raw = str(info.get("update_frequency", "-"))
@@ -148,9 +137,7 @@ def print_data_sources_table(stats: Mapping[str, Mapping[str, Any]]) -> None:
             [
                 source_map.get(source, source),
                 rpc_url,
-                doc,
                 count,
-                last3_str,
                 avg_len,
                 total,
                 freq,

--- a/tests/test_onchain_sentiment.py
+++ b/tests/test_onchain_sentiment.py
@@ -1,7 +1,7 @@
 import types, sys
 
 
-def test_chain_sentiment_included(monkeypatch, tmp_path):
+def test_onchain_sentiment_included(monkeypatch, tmp_path):
     pandas_module = types.ModuleType("pandas")
     pandas_module.DataFrame = type("DataFrame", (), {})
     pandas_module.read_excel = lambda *a, **k: pandas_module.DataFrame()
@@ -50,4 +50,4 @@ def test_chain_sentiment_included(monkeypatch, tmp_path):
 
     main.main()
 
-    assert any(b.get("source") == "chain" for b in captured.get("batches", []))
+    assert any(b.get("source") == "onchain" for b in captured.get("batches", []))


### PR DESCRIPTION
## Summary
- rename data source key from `chain` to `onchain`
- remove `evm_chain` metrics and exclude them from data source table
- streamline data source table headers and align tests with new naming

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7f8907c38832298c36ea3092ed0e3