### PR TITLE
Use 'onchain' sentiment source and simplify embedding table

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -192,25 +192,6 @@ def main() -> None:
     )
     batch_id += 1
 
-    evm_text = json.dumps(evm_kpis)
-    evm_res = _analyse([evm_text])
-    evm_ctx_size = len(evm_text.encode("utf-8")) / 1024 if evm_text else 0.0
-    try:
-        ollama_api.embed_text(evm_text)
-        evm_embedded = True
-    except Exception:
-        evm_embedded = False
-    stats["sentiment_batches"].append(
-        {
-            "batch_id": batch_id,
-            "source": "evm_chain",
-            "ctx_size_kb": evm_ctx_size,
-            "sentiment": evm_res.get("sentiment", ""),
-            "confidence": evm_res.get("confidence", 0.0),
-            "embedded": evm_embedded,
-        }
-    )
-    batch_id += 1
     # chain_kpis = []
 
     print("🔄 Analysing governance history …")

--- a/tests/test_onchain_sentiment.py
+++ b/tests/test_onchain_sentiment.py
@@ -50,4 +50,6 @@ def test_onchain_sentiment_included(monkeypatch, tmp_path):
 
     main.main()
 
-    assert any(b.get("source") == "onchain" for b in captured.get("batches", []))
+    batches = captured.get("batches", [])
+    assert any(b.get("source") == "onchain" for b in batches)
+    assert all(b.get("source") != "evm_chain" for b in batches)


### PR DESCRIPTION
## Summary
- log chain sentiment batches under `onchain` and omit `evm_chain` batches
- streamline `print_sentiment_embedding_table`: drop flag/overall row, skip `evm_chain`, show `onchain` as "On-chain"
- update on-chain sentiment test to reflect new batches

## Testing
- `pytest tests/test_onchain_sentiment.py tests/test_draft_forecast_table.py tests/test_table_alignment.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7fa1e0e448322a62a518fb3a716f6