### PR TITLE
Handle missing Ollama server

### DIFF
--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -234,7 +234,7 @@ def evaluate_historical_predictions(sample_size: int = 5) -> list[dict[str, Any]
     except Exception:
         return []
 
-    if df is None or df.empty:
+    if df is None or getattr(df, "empty", True):
         return []
 
     col_map = {c.lower().replace(" ", "_"): c for c in df.columns}


### PR DESCRIPTION
## Summary
- Detect when local Ollama server is unavailable and skip LLM-driven steps gracefully
- Guard sentiment and proposal drafting with explicit error handling and optional embedding
- Improve historical prediction evaluation to treat non-pandas stubs as empty data

## Testing
- `pytest tests/test_main_execution.py -q`
- `pytest tests/test_historical_prediction_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80bb0f9c88322a274b0a3db180d6b