### PR TITLE
Handle missing proposal sections gracefully

### DIFF
--- a/src/agents/proposal_generator.py
+++ b/src/agents/proposal_generator.py
@@ -93,4 +93,9 @@ def draft(
         temperature=temperature,
         max_tokens=max_tokens,
     )
-    return postprocess_draft(raw)
+    try:
+        return postprocess_draft(raw)
+    except ValueError:
+        # If the model returns an unexpected format, fall back to the raw text
+        # rather than raising and terminating the pipeline.
+        return raw.strip()

--- a/tests/test_proposal_generator.py
+++ b/tests/test_proposal_generator.py
@@ -49,3 +49,17 @@ def test_draft_strips_preamble_and_validates_sections():
     for heading in ["Title:", "Rationale:", "Action:", "Expected Impact:"]:
         assert heading in result
     assert "Here is your proposal" not in result
+
+
+def test_draft_returns_raw_when_missing_sections():
+    context = {}
+    raw = "No structured output provided"
+
+    with patch(
+        "src.agents.proposal_generator.ollama_api.generate_completion",
+        return_value=raw,
+    ):
+        result = proposal_generator.draft(context)
+
+    # When headings are missing, the raw text should be returned unchanged
+    assert result == raw

--- a/tests/test_proposal_selection.py
+++ b/tests/test_proposal_selection.py
@@ -52,6 +52,9 @@ def test_selects_highest_approval_prob(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "execute_proposal", lambda url, pk: {"extrinsic_hash": "0xexec", "block_hash": "0xblock"})
     monkeypatch.setattr(main, "record_execution_result", lambda **kwargs: None)
 
+    # Avoid network calls to the local Ollama server
+    monkeypatch.setattr(main.ollama_api, "check_server", lambda: None)
+
     records = []
     def fake_record_proposal(text, sid, stage=None):
         records.append((text, sid, stage))


### PR DESCRIPTION
## Summary
- avoid ValueError if LLM draft lacks required headings by returning raw text
- add regression test for missing proposal headings
- fix proposal selection test to stub Ollama server check

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b827e8e5ec83229f0d9d555d5292e3