### PR TITLE
Add configurable timeouts and summary parameters

### DIFF
--- a/src/agents/proposal_generator.py
+++ b/src/agents/proposal_generator.py
@@ -68,6 +68,7 @@ def draft(
     context_dict: Dict[str, Any],
     temperature: float | None = None,
     max_tokens: int | None = None,
+    timeout: float | None = None,
 ) -> str:
     """Return a proposal generated from ``context_dict``.
 
@@ -85,6 +86,11 @@ def draft(
         if max_tokens is not None
         else int(os.getenv("PROPOSAL_MAX_TOKENS", "4096"))
     )
+    timeout = (
+        timeout
+        if timeout is not None
+        else float(os.getenv("PROPOSAL_TIMEOUT", os.getenv("OLLAMA_TIMEOUT", "240")))
+    )
     prompt = build_prompt(context_dict)
     raw = ollama_api.generate_completion(
         prompt=prompt,
@@ -92,6 +98,7 @@ def draft(
         model="gemma3:4b",
         temperature=temperature,
         max_tokens=max_tokens,
+        timeout=timeout,
     )
     try:
         return postprocess_draft(raw)

--- a/tests/test_proposal_generator.py
+++ b/tests/test_proposal_generator.py
@@ -25,6 +25,7 @@ def test_draft_uses_build_prompt_and_ollama():
         model="gemma3:4b",
         temperature=0.3,
         max_tokens=4096,
+        timeout=240.0,
     )
     assert result == sample
 


### PR DESCRIPTION
## Summary
- Add `DEFAULT_TIMEOUT` and optional `timeout` parameter to Ollama API helpers, wiring through generate and embed calls.
- Allow context summarisation and proposal drafting to read timeout, temperature, and max token limits from environment variables.
- Adjust tests to account for new timeout setting in proposal generation.

## Testing
- `pytest tests/test_context_generation.py tests/test_proposal_generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68b83b402ea483228e4d031560eca11d