### PR TITLE
Integrate news articles into trend extraction

### DIFF
--- a/tests/test_trending_topics.py
+++ b/tests/test_trending_topics.py
@@ -1,0 +1,29 @@
+import pytest
+
+from agents.data_collector import DataCollector
+
+
+def test_trending_topics_include_news_and_weights():
+    messages = {
+        "chat": ["Polkadot upgrades are awesome", "Polkadot community grows"],
+    }
+    news = {
+        "articles": [
+            {
+                "title": "Polkadot upgrades on track",
+                "body": "Community grows rapidly",
+                "likes": 10,
+                "comments": 5,
+            }
+        ]
+    }
+
+    data = DataCollector.collect(
+        msg_fn=lambda: messages, news_fn=lambda: news, block_fn=lambda: []
+    )
+
+    trending = data["trending_topics"]
+    weights = data["stats"]["trending_topics"]
+
+    assert "polkadot upgrades" in trending
+    assert weights["polkadot upgrades"] == pytest.approx(17.0)


### PR DESCRIPTION
## Summary
- include news article titles and bodies in trending topic extraction
- weight topics by source engagement and expose per-topic weights via stats
- add regression test covering news and social bigram weighting

## Testing
- `pytest` *(fails: TypeError in test_llm)*
- `pytest tests/test_trending_topics.py`
- `pytest tests/test_data_collector_governance_stats.py tests/test_evm_data_fetcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68b86d65cb4483229ea11858bd75a048