### PR TITLE
Propagate source weights through context

### DIFF
--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -113,11 +113,17 @@ def test_record_context_persist(tmp_path, monkeypatch):
     # header then one row
     assert rows[0] == ("timestamp", "context_json")
     stored = json.loads(rows[1][1])
-    assert stored["sentiment"] == sentiment
-    assert stored["news"] == news
-    assert stored["chain_kpis"] == chain
-    assert stored["governance_kpis"] == gov
-    assert stored["evm_kpis"] == evm
+    def _strip_meta(section):
+        sec = stored[section].copy()
+        sec.pop("source", None)
+        sec.pop("weight", None)
+        return sec
+
+    assert _strip_meta("sentiment") == sentiment
+    assert _strip_meta("news") == news
+    assert _strip_meta("chain_kpis") == chain
+    assert _strip_meta("governance_kpis") == gov
+    assert _strip_meta("evm_kpis") == evm
     assert stored["trending_topics"] == []
     assert stored["kb_snippets"] == snippets
     assert stored["kb_summary"] == "summary"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -15,7 +15,7 @@ def test_post_raises_ollama_error(monkeypatch):
 def test_generate_completion_builds_payload(monkeypatch):
     captured = {}
 
-    def fake_post(url, payload):
+    def fake_post(url, payload, **kwargs):
         captured["url"] = url
         captured["payload"] = payload
         return {"response": "answer  "}
@@ -37,7 +37,7 @@ def test_generate_completion_builds_payload(monkeypatch):
 
 
 def test_embed_text_uses_post(monkeypatch):
-    def fake_post(url, payload):
+    def fake_post(url, payload, **kwargs):
         assert url == ollama_api.EMBED_URL
         assert payload == {"model": "m", "prompt": "text"}
         return {"embedding": [0.1, 0.2]}


### PR DESCRIPTION
## Summary
- annotate each context section with its source name and weighting
- plumb DataCollector weight map through main to context builder
- adjust tests for new metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86f78007c8322846c2ee35ed94a96