### PR TITLE
Filter HTML noise from trending topics

### DIFF
--- a/tests/test_trending_topics.py
+++ b/tests/test_trending_topics.py
@@ -27,3 +27,38 @@ def test_trending_topics_include_news_and_weights():
 
     assert "polkadot upgrades" in trending
     assert weights["polkadot upgrades"] == pytest.approx(17.0)
+
+
+def test_html_noise_dropped_from_trending():
+    messages = {
+        "chat": [
+            "<div>style element node style element</div>",
+            "<p>style element node style element</p>",
+        ]
+    }
+
+    data = DataCollector.collect(
+        msg_fn=lambda: messages, news_fn=lambda: {}, block_fn=lambda: []
+    )
+
+    assert data["trending_topics"] == []
+    assert data["stats"]["trending_topics"] == {}
+
+
+def test_valid_topic_survives_html_noise():
+    messages = {
+        "chat": [
+            "<div>Polkadot upgrade style element</div>",
+            "<p>Polkadot upgrade node style element</p>",
+        ]
+    }
+
+    data = DataCollector.collect(
+        msg_fn=lambda: messages, news_fn=lambda: {}, block_fn=lambda: []
+    )
+
+    trending = data["trending_topics"]
+    weights = data["stats"]["trending_topics"]
+
+    assert trending == ["polkadot upgrade"]
+    assert weights["polkadot upgrade"] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- ignore stop words and HTML/CSS terms when extracting trending bigrams
- skip non-alphabetic tokens and enforce a minimum frequency for trending topics
- test HTML-heavy inputs to ensure only meaningful topics are returned

## Testing
- `python -m pytest tests/test_trending_topics.py tests/test_data_collector.py tests/test_data_collector_governance_stats.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9120202d4832296ef8487365a0c1f