### PR TITLE
feat: allow disabling trending topics in prompt

### DIFF
--- a/src/agents/proposal_generator.py
+++ b/src/agents/proposal_generator.py
@@ -26,11 +26,17 @@ def _json_default(value: Any) -> str:
 
 def build_prompt(context: Dict[str, Any]) -> str:
     """Compose a single prompt for the LLM with all context JSON."""
-    topics = context.get("trending_topics", [])
+    include_topics = os.getenv("PROPOSAL_INCLUDE_TOPICS", "0").lower() not in (
+        "0",
+        "false",
+        "no",
+    )
     topics_section = ""
-    if topics:
-        bullet_list = "\n".join(f"- {topic}" for topic in topics)
-        topics_section = f"Trending Topics:\n{bullet_list}\n\n"
+    if include_topics:
+        topics = context.get("trending_topics", [])
+        if topics:
+            bullet_list = "\n".join(f"- {topic}" for topic in topics)
+            topics_section = f"Trending Topics:\n{bullet_list}\n\n"
     return (
         "You are an autonomous Polkadot governance agent. "
         "Using context derived from community chat, forum discussions, news "

--- a/src/main.py
+++ b/src/main.py
@@ -114,7 +114,6 @@ def main() -> None:
     def _draft(ctx: dict[str, Any]):
         if not llm_available:
             return ""
-        ctx = {**ctx, "trending_topics": trending_topics}
         try:
             try:
                 return proposal_generator.draft(

--- a/tests/test_proposal_generator.py
+++ b/tests/test_proposal_generator.py
@@ -3,6 +3,20 @@ from unittest.mock import patch
 from src.agents import proposal_generator
 
 
+def test_build_prompt_omits_trending_topics_by_default(monkeypatch):
+    monkeypatch.delenv("PROPOSAL_INCLUDE_TOPICS", raising=False)
+    context = {"trending_topics": ["x"], "foo": "bar"}
+    prompt = proposal_generator.build_prompt(context)
+    assert "Trending Topics:" not in prompt
+
+
+def test_build_prompt_includes_trending_topics_when_enabled(monkeypatch):
+    monkeypatch.setenv("PROPOSAL_INCLUDE_TOPICS", "1")
+    context = {"trending_topics": ["a", "b"], "foo": "bar"}
+    prompt = proposal_generator.build_prompt(context)
+    assert "Trending Topics:" in prompt
+
+
 def test_draft_uses_build_prompt_and_ollama():
     context = {"foo": "bar"}
     expected_prompt = proposal_generator.build_prompt(context)


### PR DESCRIPTION
## Summary
- gate trending topic bullet section in proposal prompts behind `PROPOSAL_INCLUDE_TOPICS`
- stop injecting `trending_topics` into draft context
- test prompt behavior with and without the feature flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b918097a8883229e77b9cd3a171dac