### PR TITLE
feat: split proposal sheets by stage

### DIFF
--- a/src/data_processing/data_loader.py
+++ b/src/data_processing/data_loader.py
@@ -35,7 +35,13 @@ def load_governance_data(sheet_name=None):
         if sheet_name is None:
             return {
                 s: pd.DataFrame()
-                for s in ("Referenda", "Proposals", "ExecutionResults", "Context")
+                for s in (
+                    "Referenda",
+                    "DraftedProposals",
+                    "Proposal",
+                    "ExecutionResults",
+                    "Context",
+                )
             }
         # Requested sheet (including "Context") should yield an empty DataFrame
         return pd.DataFrame()
@@ -58,9 +64,12 @@ def load_first_sheet() -> pd.DataFrame:
 
 
 def load_proposals() -> pd.DataFrame:
-    """Return the ``Proposals`` worksheet as a DataFrame (empty if missing)."""
+    """Return proposal worksheets as a single DataFrame (empty if missing)."""
     try:
-        return load_governance_data(sheet_name="Proposals")
+        df = load_governance_data(sheet_name=["DraftedProposals", "Proposal"])
+        if isinstance(df, dict):
+            return pd.concat(df.values(), ignore_index=True)
+        return df
     except Exception:
         return pd.DataFrame()
 

--- a/src/main.py
+++ b/src/main.py
@@ -427,6 +427,7 @@ def main() -> None:
             forecast_confidence=approval_prob,
             source_weight=sent_w,
             score=score,
+            sheet="DraftedProposals",
         )
     try:
         df_pred = pd.DataFrame(
@@ -491,6 +492,7 @@ def main() -> None:
         forecast_confidence=approval_prob,
         source_weight=final_source_weight,
         score=score,
+        sheet="Proposal",
     )
     record_proposal(
         proposal_text,
@@ -500,6 +502,7 @@ def main() -> None:
         forecast_confidence=approval_prob,
         source_weight=final_source_weight,
         score=score,
+        sheet="Proposal",
     )
     if submission_id:
         print(f"🔗 Proposal submitted → {submission_id}")

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -595,7 +595,7 @@ def summarise_draft_predictions(
 
     The provided ``drafts`` list may be empty if no drafts were generated in the
     current run.  In that case, this function falls back to the persisted
-    ``Proposals`` worksheet and produces forecasts for any rows marked with a
+    ``DraftedProposals`` worksheet and produces forecasts for any rows marked with a
     ``stage`` of ``draft``.
     """
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -19,7 +19,8 @@ def test_missing_workbook_returns_all_empty(monkeypatch, tmp_path):
 
     assert set(data.keys()) == {
         "Referenda",
-        "Proposals",
+        "DraftedProposals",
+        "Proposal",
         "ExecutionResults",
         "Context",
     }

--- a/tests/test_proposal_persistence.py
+++ b/tests/test_proposal_persistence.py
@@ -10,7 +10,7 @@ def test_record_proposal_persists(tmp_path, monkeypatch):
         "Test proposal text", submission_id="ABC123", stage="draft"
     )
 
-    df = pd.read_excel(temp_xlsx, sheet_name="Proposals")
+    df = pd.read_excel(temp_xlsx, sheet_name="DraftedProposals")
 
     assert len(df) == 1
     assert df.loc[0, "proposal_text"] == "Test proposal text"
@@ -28,7 +28,7 @@ def test_stage_column_added_if_missing(tmp_path, monkeypatch):
 
     wb = Workbook()
     ws = wb.active
-    ws.title = "Proposals"
+    ws.title = "DraftedProposals"
     ws.append(["timestamp", "proposal_text", "submission_id"])
     ws.append(["t1", "Old", "111"])
     wb.save(temp_xlsx)
@@ -36,7 +36,7 @@ def test_stage_column_added_if_missing(tmp_path, monkeypatch):
 
     proposal_store.record_proposal("New", submission_id="222", stage="draft")
 
-    df = pd.read_excel(temp_xlsx, sheet_name="Proposals", dtype=str)
+    df = pd.read_excel(temp_xlsx, sheet_name="DraftedProposals", dtype=str)
     assert "stage" in df.columns
     assert df.loc[df["submission_id"] == "222", "stage"].iat[0] == "draft"
 
@@ -50,7 +50,7 @@ def test_additional_fields_persist(tmp_path, monkeypatch):
         forecast_confidence=0.8, source_weight=0.5
     )
 
-    df = pd.read_excel(temp_xlsx, sheet_name="Proposals")
+    df = pd.read_excel(temp_xlsx, sheet_name="DraftedProposals")
 
     row = df.loc[0]
     assert row["source"] == "chat"

--- a/tests/test_record_execution_result.py
+++ b/tests/test_record_execution_result.py
@@ -46,6 +46,6 @@ def test_execution_result_links_to_proposal(tmp_path, monkeypatch):
     import pandas as pd
 
     df_exec = pd.read_excel(temp_xlsx, sheet_name="ExecutionResults")
-    df_prop = pd.read_excel(temp_xlsx, sheet_name="Proposals")
+    df_prop = pd.read_excel(temp_xlsx, sheet_name="Proposal")
     submitted_row = df_prop.index[df_prop["submission_id"] == "SID"][0] + 2
     assert int(df_exec.loc[0, "proposal_row"]) == submitted_row

--- a/tests/test_workbook_creation.py
+++ b/tests/test_workbook_creation.py
@@ -9,6 +9,12 @@ def test_ensure_workbook_creates_required_sheets(tmp_path, monkeypatch):
     proposal_store.ensure_workbook()
     wb = load_workbook(tmp_xlsx)
 
-    expected = {"Referenda", "Proposals", "Context", "ExecutionResults"}
+    expected = {
+        "Referenda",
+        "DraftedProposals",
+        "Proposal",
+        "Context",
+        "ExecutionResults",
+    }
     assert set(wb.sheetnames) == expected
     assert "Sheet" not in wb.sheetnames


### PR DESCRIPTION
## Summary
- add `DraftedProposals` and `Proposal` worksheets to the governance workbook
- route stored proposals to the correct sheet based on stage and expose sheet override
- update pipeline to specify the destination sheet when recording proposals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b919c6a7e0832294609acbd67d5910