### PR TITLE
Extend outcome forecasting with sentiment sources and historical metrics

### DIFF
--- a/models/referendum_model.json
+++ b/models/referendum_model.json
@@ -3,10 +3,12 @@
   "coefficients": {
     "approval_rate": 0.8,
     "turnout": 0.2,
-    "sentiment": 0.0,
+    "sentiment": 0.3,
     "trending": 0.0,
     "proposal_length": 0.0,
     "engagement_weight": 0.0,
-    "turnout_trend": 0.0
+    "turnout_trend": 0.0,
+    "source_sentiment_avg": 0.1,
+    "comment_turnout_trend": 0.05
   }
 }

--- a/src/analysis/train_forecaster.py
+++ b/src/analysis/train_forecaster.py
@@ -24,10 +24,12 @@ def _prepare_features(df: pd.DataFrame) -> Tuple[pd.DataFrame, np.ndarray, List[
 
     ``approval_rate``  – ayes divided by total voted DOT
     ``turnout``        – participants divided by eligible DOT
-    ``sentiment``      – sentiment score from sentiment analysis (column name
-                         ``sentiment_score`` or ``sentiment``)
-    ``trending``       – trending topic metric (column ``trend_score`` or
-                         ``trending_score``)
+    ``sentiment``            – sentiment score from sentiment analysis (column
+                                name ``sentiment_score`` or ``sentiment``)
+    ``trending``             – trending topic metric (column ``trend_score`` or
+                                ``trending_score``)
+    ``source_sentiment_avg`` – pre-computed average sentiment across sources
+    ``comment_turnout_trend``– turnout trend derived from historical comments
     """
 
     df = df.copy()
@@ -61,12 +63,24 @@ def _prepare_features(df: pd.DataFrame) -> Tuple[pd.DataFrame, np.ndarray, List[
         trending = pd.Series(0.0, index=df.index)
     trending = trending.astype(float).fillna(0.0)
 
+    source_avg = df.get("source_sentiment_avg")
+    if source_avg is None:
+        source_avg = pd.Series(0.0, index=df.index)
+    source_avg = source_avg.astype(float).fillna(0.0)
+
+    comment_trend = df.get("comment_turnout_trend")
+    if comment_trend is None:
+        comment_trend = pd.Series(0.0, index=df.index)
+    comment_trend = comment_trend.astype(float).fillna(0.0)
+
     features = pd.DataFrame(
         {
             "approval_rate": approval_rate,
             "turnout": turnout,
             "sentiment": sentiment,
             "trending": trending,
+            "source_sentiment_avg": source_avg,
+            "comment_turnout_trend": comment_trend,
         }
     )
     return features, y.to_numpy(), list(features.columns)

--- a/tests/test_forecaster_training.py
+++ b/tests/test_forecaster_training.py
@@ -1,4 +1,5 @@
 import json
+import json
 from pathlib import Path
 
 import numpy as np
@@ -17,6 +18,8 @@ def test_training_improves_accuracy():
             "Eligible_DOT": [100, 100, 100, 100],
             "sentiment_score": [0.8, -0.7, 0.6, -0.5],
             "trend_score": [0.7, -0.6, 0.5, -0.4],
+            "source_sentiment_avg": [0.8, -0.7, 0.6, -0.5],
+            "comment_turnout_trend": [0.7, -0.6, 0.5, -0.4],
             "Status": ["Executed", "Rejected", "Executed", "Rejected"],
         }
     )
@@ -33,6 +36,8 @@ def test_training_improves_accuracy():
             "turnout": 0.5,
             "sentiment": s,
             "trending": t,
+            "source_sentiment_avg": s,
+            "comment_turnout_trend": t,
         }
         for s, t in zip(df["sentiment_score"], df["trend_score"])
     ]

--- a/tests/test_historical_prediction_fallback.py
+++ b/tests/test_historical_prediction_fallback.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from src.reporting.summary_tables import evaluate_historical_predictions
+from src.data_processing import referenda_updater
 
 
 def test_historical_prediction_fallback(monkeypatch):
@@ -17,7 +18,9 @@ def test_historical_prediction_fallback(monkeypatch):
         "src.reporting.summary_tables.load_governance_data", lambda sheet_name="Referenda": df
     )
     monkeypatch.setattr(
-        "src.agents.outcome_forecaster.load_governance_data", lambda sheet_name="Referenda": df
+        referenda_updater,
+        "load_historical_rates",
+        lambda: {"approval_rate": 0.5, "turnout": 0.5, "turnout_trend": 0.0},
     )
 
     # Ensure deterministic sampling

--- a/tests/test_prediction_analysis.py
+++ b/tests/test_prediction_analysis.py
@@ -2,26 +2,24 @@ import json
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 
 from src.agents.outcome_forecaster import forecast_outcomes
-from src.data_processing import data_loader
+from src.data_processing import referenda_updater
 
 
 def test_forecast_outcomes_fields_and_ranges(tmp_path, monkeypatch):
-    df = pd.DataFrame(
-        {
-            "Status": ["Executed", "Rejected"],
-            "Voted_percentage": [60.0, 40.0],
-            "Participants": [100, 80],
-            "Eligible_DOT": [200, 200],
-        }
+    monkeypatch.setattr(
+        referenda_updater,
+        "load_historical_rates",
+        lambda: {"approval_rate": 0.5, "turnout": 0.5, "turnout_trend": 0.02},
     )
-    path = tmp_path / "PKD Governance Data.xlsx"
-    df.to_excel(path, sheet_name="Referenda", index=False)
-    monkeypatch.setattr(data_loader, "FILE_PATH", path)
 
-    context = {"sentiment_score": 0.2, "trending_score": 0.1}
+    context = {
+        "sentiment_score": 0.2,
+        "trending_score": 0.1,
+        "source_sentiments": {"news": 0.3, "forum": 0.1},
+        "comment_turnout_trend": 0.05,
+    }
     result = forecast_outcomes(context)
     assert set(result.keys()) == {"approval_prob", "turnout_estimate"}
     assert 0.0 <= result["approval_prob"] <= 1.0
@@ -37,7 +35,23 @@ def test_forecast_outcomes_fields_and_ranges(tmp_path, monkeypatch):
         + coeffs.get("turnout", 0.0) * 0.5
         + coeffs.get("sentiment", 0.0) * 0.2
         + coeffs.get("trending", 0.0) * 0.1
+        + coeffs.get("source_sentiment_avg", 0.0) * 0.2
+        + coeffs.get("comment_turnout_trend", 0.0) * 0.05
     )
     expected = 1 / (1 + np.exp(-z))
     assert round(result["approval_prob"], 3) == round(expected, 3)
     assert round(result["turnout_estimate"], 2) == 0.5
+
+
+def test_probability_increases_with_sentiment(monkeypatch):
+    monkeypatch.setattr(
+        referenda_updater,
+        "load_historical_rates",
+        lambda: {"approval_rate": 0.5, "turnout": 0.5, "turnout_trend": 0.0},
+    )
+
+    ctx_low = {"source_sentiments": {"news": -0.5}}
+    ctx_high = {"source_sentiments": {"news": 0.5}}
+    low = forecast_outcomes(ctx_low)["approval_prob"]
+    high = forecast_outcomes(ctx_high)["approval_prob"]
+    assert high > low


### PR DESCRIPTION
## Summary
- pull historical approval, turnout rates, and trends via `referenda_updater.load_historical_rates`
- expand `forecast_outcomes` to handle per-source sentiment averages and comment-driven turnout trends
- retrain model coefficients and update training utilities and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b91ce7224c8322b5cb084315ae4d6a