### PR TITLE
Add old referenda context handling

### DIFF
--- a/src/agents/context_generator.py
+++ b/src/agents/context_generator.py
@@ -142,6 +142,7 @@ def build_context(
     kb_snippets: list[str] | None = None,
     kb_query: str | None = None,
     *,
+    old_referenda: Dict[str, Any] | None = None,
     trending_topics: list[str] | None = None,
     dedup_snippets: bool = True,
     summarise_snippets: bool = False,
@@ -185,6 +186,7 @@ def build_context(
     news_src, news_w = _info("news", "news", "DATA_WEIGHT_NEWS")
     chain_src, chain_w = _info("chain_kpis", "onchain", "DATA_WEIGHT_CHAIN")
     gov_src, gov_w = _info("governance_kpis", "governance", "DATA_WEIGHT_GOVERNANCE")
+    old_src, old_w = _info("old_referenda", "old_referenda", "DATA_WEIGHT_OLD_REFERENDA")
 
     context = {
         "timestamp_utc": utc_now_iso(),
@@ -197,6 +199,9 @@ def build_context(
         "kb_summary": summary,
         "kb_embedded": embedded,
     }
+
+    if old_referenda:
+        context["old_referenda"] = _wrap(old_referenda, old_src, old_w)
 
     # Persist for audit trail – ignore failures from missing dependencies
     try:

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -546,6 +546,8 @@ def draft_onchain_proposal(
     gov_kpis: Mapping[str, Any],
     query: str,
     trending_topics: list[str] | None = None,
+    *,
+    old_referenda: Mapping[str, Any] | None = None,
     source_weight: float = 1.0,
 ) -> dict[str, Any] | None:
     """Draft a proposal using only on-chain metrics."""
@@ -561,6 +563,7 @@ def draft_onchain_proposal(
         kb_query=query,
         trending_topics=trending_topics,
         summarise_snippets=True,
+        old_referenda=old_referenda,
     )
     chain_draft = proposal_generator.draft(ctx_chain)
     t_pred = time.perf_counter()


### PR DESCRIPTION
## Summary
- load recent executed referenda comments for context
- include old referenda summaries as `old_referenda` in build_context
- propagate old referenda context through proposal drafting and persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9233ad4b48322bdc6d6968dfefd75