### PR TITLE
Aggregate sentiment sources and turnout trends for forecasts

### DIFF
--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -549,6 +549,8 @@ def draft_onchain_proposal(
     *,
     old_referenda: Mapping[str, Any] | None = None,
     source_weight: float = 1.0,
+    source_sentiments: Mapping[str, float] | None = None,
+    comment_turnout_trend: float | None = None,
 ) -> dict[str, Any] | None:
     """Draft a proposal using only on-chain metrics."""
 
@@ -565,6 +567,10 @@ def draft_onchain_proposal(
         summarise_snippets=True,
         old_referenda=old_referenda,
     )
+    if source_sentiments:
+        ctx_chain["source_sentiments"] = dict(source_sentiments)
+    if comment_turnout_trend is not None:
+        ctx_chain["comment_turnout_trend"] = comment_turnout_trend
     chain_draft = proposal_generator.draft(ctx_chain)
     t_pred = time.perf_counter()
     chain_forecast = forecast_outcomes(ctx_chain)

--- a/tests/test_outcome_forecaster.py
+++ b/tests/test_outcome_forecaster.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+from src.agents.outcome_forecaster import forecast_outcomes
+from src.data_processing import referenda_updater
+
+
+def test_probability_varies_with_sentiment(monkeypatch):
+    monkeypatch.setattr(
+        referenda_updater,
+        "load_historical_rates",
+        lambda: {"approval_rate": 0.5, "turnout": 0.5, "turnout_trend": 0.0},
+    )
+    low = forecast_outcomes({"source_sentiments": {"chat": -0.5}})["approval_prob"]
+    high = forecast_outcomes({"source_sentiments": {"chat": 0.5}})["approval_prob"]
+    assert high > low
+
+
+def test_probability_varies_with_comment_trend(monkeypatch):
+    monkeypatch.setattr(
+        referenda_updater,
+        "load_historical_rates",
+        lambda: {"approval_rate": 0.5, "turnout": 0.5, "turnout_trend": 0.0},
+    )
+    low = forecast_outcomes({"comment_turnout_trend": -0.2})["approval_prob"]
+    high = forecast_outcomes({"comment_turnout_trend": 0.2})["approval_prob"]
+
+    model_path = Path(__file__).resolve().parents[1] / "models" / "referendum_model.json"
+    with model_path.open() as f:
+        coeff = json.load(f)["coefficients"].get("comment_turnout_trend", 0.0)
+    if coeff >= 0:
+        assert high > low
+    else:
+        assert high < low


### PR DESCRIPTION
## Summary
- Aggregate per-source sentiment scores in main pipeline and attach to every forecasting context
- Extend executed referenda loader to compute comment turnout trends and supply them to forecasting
- Enhance outcome forecaster tests to confirm sentiment and comment turnout impact probabilities

## Testing
- `pytest tests/test_outcome_forecaster.py tests/test_prediction_analysis.py tests/test_main_pipeline.py tests/test_main_execution.py`
- `pytest tests/test_draft_forecast_table.py`

------
https://chatgpt.com/codex/tasks/task_e_68b92804e8588322a98ac9e2fd95f5e3