### PR TITLE
Persist full context in proposal artifact JSON

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -103,6 +103,7 @@ def _save_proposal_artifact(
         "text": text,
         "source": source,
         "context_snippet": snippet,
+        "context": context,
         "forecast": forecast,
     }
     (OUT_DIR / f"draft_{source}_{timestamp}.json").write_text(

--- a/tests/test_main_execution.py
+++ b/tests/test_main_execution.py
@@ -1,5 +1,5 @@
 def test_main_records_final_status(monkeypatch, tmp_path):
-    import types, sys
+    import types, sys, json
     # Stub heavy dependencies before importing main
     pandas_module = types.ModuleType("pandas")
     pandas_module.DataFrame = type("DataFrame", (), {})
@@ -86,6 +86,12 @@ def test_main_records_final_status(monkeypatch, tmp_path):
     monkeypatch.setenv("GOVERNANCE_TRACK", "root")
 
     main.main()
+
+    # The final proposal artifact should include the full context
+    proposal_files = list(tmp_path.glob("proposal_*.json"))
+    assert proposal_files, "No final proposal artifact generated"
+    payload = json.loads(proposal_files[0].read_text())
+    assert "context" in payload
 
     assert recorded == {
         "status": "Executed",

--- a/tests/test_main_pipeline.py
+++ b/tests/test_main_pipeline.py
@@ -2,6 +2,7 @@ import types
 import sys
 import importlib
 import types
+import json
 import pytest
 
 
@@ -100,6 +101,12 @@ def test_pipeline_skips_empty_source(empty_fetcher, skipped_source, monkeypatch,
         monkeypatch.setattr(main, "get_recent_blocks_cached", lambda: [])
 
     main.main()
+
+    # Ensure the draft JSON includes the full context
+    draft_files = list(tmp_path.glob("draft_*.json"))
+    assert draft_files, "No draft artifact generated"
+    payload = json.loads(draft_files[0].read_text())
+    assert "context" in payload
 
     assert skipped_source not in recorded_sources
     # At least one proposal draft should exist from remaining data


### PR DESCRIPTION
## Summary
- Include complete context alongside snippet in `_save_proposal_artifact`
- Update pipeline tests to validate presence of full context in saved artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b929f63a008322b0f8c37b09bbbbd8