### PR TITLE
Make trending topics optional in context generation

### DIFF
--- a/src/agents/context_generator.py
+++ b/src/agents/context_generator.py
@@ -194,11 +194,13 @@ def build_context(
         "news": _wrap(news, news_src, news_w),
         "chain_kpis": _wrap(chain_kpis, chain_src, chain_w),
         "governance_kpis": _wrap(gov_kpis, gov_src, gov_w),
-        "trending_topics": trending_topics or [],
         "kb_snippets": snippets,
         "kb_summary": summary,
         "kb_embedded": embedded,
     }
+
+    if trending_topics is not None:
+        context["trending_topics"] = trending_topics
 
     if old_referenda:
         context["old_referenda"] = _wrap(old_referenda, old_src, old_w)
@@ -209,7 +211,9 @@ def build_context(
     except Exception:
         pass
     # Retrieve and merge historical proposals based on trending topics
-    historical = proposal_store.retrieve_recent(trending_topics or [])
+    historical = (
+        proposal_store.retrieve_recent(trending_topics) if trending_topics else []
+    )
     if historical:
         context["historical_proposals"] = historical
     return context

--- a/src/main.py
+++ b/src/main.py
@@ -67,6 +67,11 @@ PROPOSAL_MAX_TOKENS = int(os.getenv("PROPOSAL_MAX_TOKENS", "4096"))
 NEWS_TEMPERATURE = float(os.getenv("NEWS_TEMPERATURE", "0.2"))
 NEWS_MAX_TOKENS = int(os.getenv("NEWS_MAX_TOKENS", "1024"))
 VERBOSE = os.getenv("VERBOSE", "0").lower() in {"1", "true", "yes"}
+INCLUDE_TOPICS = os.getenv("PROPOSAL_INCLUDE_TOPICS", "0").lower() not in {
+    "0",
+    "false",
+    "no",
+}
 
 
 def _json_default(obj: Any) -> str:
@@ -294,16 +299,20 @@ def main(verbose: bool | None = None) -> None:
                 "weight": weights_by_source.get("governance", 1.0),
             },
         }
+        ctx_kwargs = {
+            "kb_query": query,
+            "summarise_snippets": True,
+            "source_weight": sw_map,
+            "old_referenda": old_ref_res,
+        }
+        if INCLUDE_TOPICS:
+            ctx_kwargs["trending_topics"] = trending_topics
         ctx = build_context(
             sentiments_by_source.get(source, {}),
             {},
             chain_kpis,
             gov_kpis,
-            kb_query=query,
-            trending_topics=trending_topics,
-            summarise_snippets=True,
-            source_weight=sw_map,
-            old_referenda=old_ref_res,
+            **ctx_kwargs,
         )
         ctx["source_sentiments"] = source_sentiments
         ctx["comment_turnout_trend"] = comment_turnout_trend
@@ -349,16 +358,20 @@ def main(verbose: bool | None = None) -> None:
                 "weight": weights_by_source.get("governance", 1.0),
             },
         }
+        ctx_kwargs = {
+            "kb_query": query,
+            "summarise_snippets": True,
+            "source_weight": sw_map_news,
+            "old_referenda": old_ref_res,
+        }
+        if INCLUDE_TOPICS:
+            ctx_kwargs["trending_topics"] = trending_topics
         ctx_news = build_context(
             {},
             news,
             chain_kpis,
             gov_kpis,
-            kb_query=query,
-            trending_topics=trending_topics,
-            summarise_snippets=True,
-            source_weight=sw_map_news,
-            old_referenda=old_ref_res,
+            **ctx_kwargs,
         )
         ctx_news["source_sentiments"] = source_sentiments
         ctx_news["comment_turnout_trend"] = comment_turnout_trend
@@ -402,7 +415,7 @@ def main(verbose: bool | None = None) -> None:
             chain_kpis,
             gov_kpis,
             query,
-            trending_topics,
+            trending_topics if INCLUDE_TOPICS else None,
             old_referenda=old_ref_res,
             source_weight=weights_by_source.get("onchain", 1.0),
             source_sentiments=source_sentiments,
@@ -452,16 +465,20 @@ def main(verbose: bool | None = None) -> None:
                 "weight": weights_by_source.get("governance", 1.0),
             },
         }
+        ctx_kwargs = {
+            "kb_query": query,
+            "summarise_snippets": True,
+            "source_weight": sw_map_cons,
+            "old_referenda": old_ref_res,
+        }
+        if INCLUDE_TOPICS:
+            ctx_kwargs["trending_topics"] = trending_topics
         context = build_context(
             sentiment,
             news,
             chain_kpis,
             gov_kpis,
-            kb_query=query,
-            trending_topics=trending_topics,
-            summarise_snippets=True,
-            source_weight=sw_map_cons,
-            old_referenda=old_ref_res,
+            **ctx_kwargs,
         )
         context["source_sentiments"] = source_sentiments
         context["comment_turnout_trend"] = comment_turnout_trend

--- a/tests/test_context_generation.py
+++ b/tests/test_context_generation.py
@@ -56,14 +56,13 @@ def test_build_context_structure_dedup_and_summary(monkeypatch):
         "news",
         "chain_kpis",
         "governance_kpis",
-        "trending_topics",
         "kb_snippets",
         "kb_summary",
         "kb_embedded",
     }
+    assert "trending_topics" not in ctx
     assert ctx["kb_snippets"] == ["previous proposal"]
     assert ctx["kb_summary"] == "summary"
-    assert ctx["trending_topics"] == []
     assert v.validate_sentiment(ctx["sentiment"])
     assert v.validate_news(ctx["news"])
     assert v.validate_chain_kpis(ctx["chain_kpis"])
@@ -112,9 +111,9 @@ def test_record_context_persist(tmp_path, monkeypatch):
     assert _strip_meta("news") == news
     assert _strip_meta("chain_kpis") == chain
     assert _strip_meta("governance_kpis") == gov
-    assert stored["trending_topics"] == []
     assert stored["kb_snippets"] == snippets
     assert stored["kb_summary"] == "summary"
+    assert "trending_topics" not in stored
 
 
 def test_component_weighting(monkeypatch):


### PR DESCRIPTION
## Summary
- Only forward trending topics into `build_context` when `PROPOSAL_INCLUDE_TOPICS` env var is truthy
- Allow `build_context` to omit the `trending_topics` key and skip historical lookups when topics are absent
- Update context generation tests for the new optional behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b92b2628888322b5a13ed7ebe23173