### PR TITLE
feat: add source-specific prompts

### DIFF
--- a/src/agents/proposal_generator.py
+++ b/src/agents/proposal_generator.py
@@ -24,7 +24,7 @@ def _json_default(value: Any) -> str:
                     "is not JSON serialisable")
 
 
-def build_prompt(context: Dict[str, Any]) -> str:
+def build_prompt(context: Dict[str, Any], source_name: str) -> str:
     """Compose a single prompt for the LLM with all context JSON."""
     include_topics = os.getenv("PROPOSAL_INCLUDE_TOPICS", "0").lower() not in (
         "0",
@@ -39,10 +39,7 @@ def build_prompt(context: Dict[str, Any]) -> str:
             topics_section = f"Trending Topics:\n{bullet_list}\n\n"
     return (
         "You are an autonomous Polkadot governance agent. "
-        "Using context derived from community chat, forum discussions, news "
-        "reports, on-chain metrics and historical referenda, draft a concise "
-        "OpenGov proposal for the 'Root' track. Reference these sources where "
-        "relevant.\n\n"
+        f"Using context derived from {source_name}. Reference these sources where relevant.\n"
         "Fill out the following template and return only the completed text:\n"
         "Title: <short heading>\n"
         "Rationale: <brief reasoning referencing sentiment, risks and prior votes>\n"
@@ -78,6 +75,7 @@ def postprocess_draft(text: str) -> str:
 
 def draft(
     context_dict: Dict[str, Any],
+    source_name: str,
     temperature: float | None = None,
     max_tokens: int | None = None,
     timeout: float | None = None,
@@ -103,7 +101,7 @@ def draft(
         if timeout is not None
         else float(os.getenv("PROPOSAL_TIMEOUT", os.getenv("OLLAMA_TIMEOUT", "360")))
     )
-    prompt = build_prompt(context_dict)
+    prompt = build_prompt(context_dict, source_name)
     raw = ollama_api.generate_completion(
         prompt=prompt,
         system="You are Polkadot-Gov-Agent v1.",

--- a/src/main.py
+++ b/src/main.py
@@ -149,18 +149,19 @@ def main(verbose: bool | None = None) -> None:
             print(f"⚠️ Sentiment analysis failed: {exc}")
             return {}
 
-    def _draft(ctx: dict[str, Any]):
+    def _draft(ctx: dict[str, Any], source_name: str):
         if not llm_available:
             return ""
         try:
             try:
                 return proposal_generator.draft(
                     ctx,
+                    source_name,
                     temperature=PROPOSAL_TEMPERATURE,
                     max_tokens=PROPOSAL_MAX_TOKENS,
                 )
             except TypeError:
-                return proposal_generator.draft(ctx)
+                return proposal_generator.draft(ctx, source_name)
         except ollama_api.OllamaError as exc:  # pragma: no cover - network dependent
             print(f"⚠️ Proposal drafting failed: {exc}")
             return ""
@@ -316,7 +317,7 @@ def main(verbose: bool | None = None) -> None:
         )
         ctx["source_sentiments"] = source_sentiments
         ctx["comment_turnout_trend"] = comment_turnout_trend
-        draft_text = _draft(ctx)
+        draft_text = _draft(ctx, source)
         t_pred = time.perf_counter()
         forecast = forecast_outcomes(ctx)
         prediction_time = time.perf_counter() - t_pred
@@ -375,7 +376,7 @@ def main(verbose: bool | None = None) -> None:
         )
         ctx_news["source_sentiments"] = source_sentiments
         ctx_news["comment_turnout_trend"] = comment_turnout_trend
-        news_draft = _draft(ctx_news)
+        news_draft = _draft(ctx_news, "news")
         t_pred = time.perf_counter()
         news_forecast = forecast_outcomes(ctx_news)
         prediction_time = time.perf_counter() - t_pred
@@ -486,7 +487,7 @@ def main(verbose: bool | None = None) -> None:
         forecast = forecast_outcomes(context)
         prediction_time = time.perf_counter() - t_pred
         context["forecast"] = forecast
-        proposal_text = _draft(context)
+        proposal_text = _draft(context, "consolidated")
         approval_prob = forecast.get("approval_prob", 0.0)
         final_source = "consolidated"
         final_source_weight = sent_w

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -571,7 +571,7 @@ def draft_onchain_proposal(
         ctx_chain["source_sentiments"] = dict(source_sentiments)
     if comment_turnout_trend is not None:
         ctx_chain["comment_turnout_trend"] = comment_turnout_trend
-    chain_draft = proposal_generator.draft(ctx_chain)
+    chain_draft = proposal_generator.draft(ctx_chain, "onchain")
     t_pred = time.perf_counter()
     chain_forecast = forecast_outcomes(ctx_chain)
     prediction_time = time.perf_counter() - t_pred

--- a/tests/test_main_pipeline.py
+++ b/tests/test_main_pipeline.py
@@ -58,7 +58,7 @@ def test_pipeline_skips_empty_source(empty_fetcher, skipped_source, monkeypatch,
     monkeypatch.setattr(main, "update_referenda", lambda max_new: None)
     monkeypatch.setattr(main, "get_governance_insights", lambda as_narrative=True: {})
     monkeypatch.setattr(main, "draft_onchain_proposal", lambda *a, **k: None)
-    monkeypatch.setattr(main.proposal_generator, "draft", lambda ctx, **kw: "draft")
+    monkeypatch.setattr(main.proposal_generator, "draft", lambda ctx, source_name, **kw: "draft")
     monkeypatch.setattr(main, "compare_predictions", lambda df: {"prediction_eval": []})
     monkeypatch.setattr(main, "evaluate_historical_predictions", lambda: [])
     monkeypatch.setattr(main, "broadcast_proposal", lambda text: None)

--- a/tests/test_onchain_sentiment.py
+++ b/tests/test_onchain_sentiment.py
@@ -30,7 +30,7 @@ def test_onchain_sentiment_included(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "forecast_outcomes", lambda ctx: {})
     monkeypatch.setattr(main, "compare_predictions", lambda df: {"prediction_eval": []})
     monkeypatch.setattr(main, "evaluate_historical_predictions", lambda: [])
-    monkeypatch.setattr(main.proposal_generator, "draft", lambda ctx: "Proposal")
+    monkeypatch.setattr(main.proposal_generator, "draft", lambda ctx, source_name: "Proposal")
     monkeypatch.setattr(main, "broadcast_proposal", lambda text: None)
     monkeypatch.setattr(
         main, "record_proposal", lambda text, sid, stage=None, **_: None

--- a/tests/test_proposal_selection.py
+++ b/tests/test_proposal_selection.py
@@ -39,14 +39,22 @@ def test_selects_highest_approval_prob(monkeypatch, tmp_path):
     monkeypatch.setattr(main, "build_context", fake_build_context)
     import src.reporting.summary_tables as summary_tables
     monkeypatch.setattr(summary_tables, "build_context", fake_build_context)
-    monkeypatch.setattr(summary_tables.proposal_generator, "draft", lambda ctx: f"Proposal {ctx.get('id', 0)}")
+    monkeypatch.setattr(
+        summary_tables.proposal_generator,
+        "draft",
+        lambda ctx, source_name: f"Proposal {ctx.get('id', 0)}",
+    )
 
     def fake_forecast(ctx):
         prob = 0.1 if ctx["id"] == 0 else 0.9
         return {"approval_prob": prob, "turnout_estimate": 0.0}
 
     monkeypatch.setattr(main, "forecast_outcomes", fake_forecast)
-    monkeypatch.setattr(main.proposal_generator, "draft", lambda ctx: f"Proposal {ctx.get('id', 0)}")
+    monkeypatch.setattr(
+        main.proposal_generator,
+        "draft",
+        lambda ctx, source_name: f"Proposal {ctx.get('id', 0)}",
+    )
     monkeypatch.setattr(main, "broadcast_proposal", lambda text: None)
     monkeypatch.setattr(main, "submit_preimage", lambda url, pk, data: {"preimage_hash": "0xpre"})
     monkeypatch.setattr(main, "submit_proposal", lambda url, pk, h, track: {"extrinsic_hash": "0xsub", "referendum_index": 1, "is_success": True})


### PR DESCRIPTION
## Summary
- allow proposal generator to accept source name and include it in prompt
- pass source names through main pipeline and summary tables
- update tests for new draft signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68babc8162c08322842cf71cd9af1493