### PR TITLE
Retry unstructured proposal drafts and enforce template

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -162,7 +162,7 @@ def main(verbose: bool | None = None) -> None:
                 )
             except TypeError:
                 return proposal_generator.draft(ctx, source_name)
-        except ollama_api.OllamaError as exc:  # pragma: no cover - network dependent
+        except (ollama_api.OllamaError, ValueError) as exc:  # pragma: no cover - network dependent
             print(f"⚠️ Proposal drafting failed: {exc}")
             return ""
 


### PR DESCRIPTION
## Summary
- Retry proposal generation when the model returns unstructured text and raise an error after exhausting attempts
- Catch template validation failures during pipeline drafting to avoid saving malformed proposals
- Test prompt building and retry behaviour for structured proposal drafts

## Testing
- `pytest tests/test_proposal_generator.py -q`
- `pytest tests/test_proposal_submission.py tests/test_proposal_selection.py tests/test_onchain_sentiment.py tests/test_main_execution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68babbca4e3883228a99829feb1ebf5d