### PR TITLE
Improve fallback forecasting heuristics and margin metrics

### DIFF
--- a/src/agents/outcome_forecaster.py
+++ b/src/agents/outcome_forecaster.py
@@ -78,12 +78,14 @@ def forecast_outcomes(context: Dict) -> Dict[str, float]:
     # Per-source sentiment averages
     src_sent = context.get("source_sentiments") or context.get("sentiment_sources")
     source_sentiment_avg = 0.0
+    source_sentiment_values = []
     if isinstance(src_sent, dict) and src_sent:
         try:
-            vals = [float(v) for v in src_sent.values()]
-            if vals:
-                source_sentiment_avg = float(np.mean(vals))
+            source_sentiment_values = [float(v) for v in src_sent.values()]
+            if source_sentiment_values:
+                source_sentiment_avg = float(np.mean(source_sentiment_values))
         except Exception:
+            source_sentiment_values = []
             source_sentiment_avg = 0.0
 
     trending_val = context.get("trend_score")
@@ -121,26 +123,72 @@ def forecast_outcomes(context: Dict) -> Dict[str, float]:
             weight_val = weight_val.get("weight")
     engagement_weight = float(weight_val or 0.0)
 
-    # Apply trained model if available
+    features = {
+        "approval_rate": approval_prob,
+        "turnout": turnout_estimate,
+        "sentiment": sentiment,
+        "trending": trending,
+        "proposal_length": proposal_length,
+        "engagement_weight": engagement_weight,
+        "turnout_trend": turnout_trend,
+        "source_sentiment_avg": source_sentiment_avg,
+        "comment_turnout_trend": comment_turnout_trend,
+    }
+
+    # Apply trained model if available; otherwise fall back to a heuristic that
+    # still incorporates contextual information so drafts with stronger
+    # sentiment/trend signals diverge from the historical average.
     model = _load_model()
+    model_applied = False
     if model is not None:
         try:
-            features = {
-                "approval_rate": approval_prob,
-                "turnout": turnout_estimate,
-                "sentiment": sentiment,
-                "trending": trending,
-                "proposal_length": proposal_length,
-                "engagement_weight": engagement_weight,
-                "turnout_trend": turnout_trend,
-                "source_sentiment_avg": source_sentiment_avg,
-                "comment_turnout_trend": comment_turnout_trend,
-            }
             approval_prob = _apply_model(model, features)
+            model_applied = True
         except Exception:
-            pass
+            model_applied = False
+
+    if not model_applied:
+        # Heuristic adjustments around the historical approval baseline.
+        adjustments = (
+            0.18 * features["sentiment"]
+            + 0.12 * features["source_sentiment_avg"]
+            + 0.10 * features["trending"]
+            + 0.15 * features["comment_turnout_trend"]
+            + 0.08 * features["turnout_trend"]
+            + 0.06 * (features["turnout"] - 0.5)
+            + 0.07 * (features["engagement_weight"] - 0.5)
+            + 0.03 * (features["proposal_length"] / 500.0)
+        )
+        approval_prob = approval_prob + adjustments
+
+    approval_prob = float(max(0.0, min(1.0, approval_prob)))
+
+    # Draft-specific uncertainty estimates use turnout volatility, sentiment
+    # dispersion and engagement weight to modulate the margin of error.  Higher
+    # volatility and disagreement inflate the margin, while stronger engagement
+    # reduces it.
+    sentiment_spread = 0.0
+    if len(source_sentiment_values) > 1:
+        sentiment_spread = float(np.std(source_sentiment_values))
+    elif source_sentiment_values:
+        sentiment_spread = float(abs(source_sentiment_values[0] - sentiment) * 0.5)
+    else:
+        sentiment_spread = float(abs(sentiment) * 0.3)
+
+    turnout_volatility = abs(features["turnout_trend"]) + abs(features["comment_turnout_trend"])
+    engagement_factor = float(max(0.0, min(1.0, features["engagement_weight"])) if not np.isnan(features["engagement_weight"]) else 0.0)
+
+    base_margin = 0.08 + 0.22 * turnout_volatility + 0.12 * sentiment_spread
+    base_margin *= 1.0 - 0.35 * engagement_factor
+    margin_of_error = float(max(0.02, min(0.45, base_margin)))
+
+    confidence = 1.0 - margin_of_error
+    confidence += 0.1 * abs(features["sentiment"]) + 0.05 * abs(features["source_sentiment_avg"])
+    confidence = float(max(0.05, min(0.95, confidence)))
 
     return {
-        "approval_prob": float(max(0.0, min(1.0, approval_prob))),
+        "approval_prob": approval_prob,
         "turnout_estimate": turnout_estimate,
+        "margin_of_error": margin_of_error,
+        "confidence": confidence,
     }

--- a/src/main.py
+++ b/src/main.py
@@ -527,9 +527,13 @@ def main(verbose: bool | None = None) -> None:
                     "predicted": "Approved"
                     if forecast.get("approval_prob", 0.0) >= 0.5
                     else "Rejected",
-                    "confidence": forecast.get("approval_prob", 0.0),
+                    "confidence": forecast.get(
+                        "confidence", forecast.get("approval_prob", 0.0)
+                    ),
                     "prediction_time": dt.datetime.now(dt.UTC).isoformat(),
-                    "margin_of_error": forecast.get("turnout_estimate", 0.0),
+                    "margin_of_error": forecast.get(
+                        "margin_of_error", forecast.get("turnout_estimate", 0.0)
+                    ),
                 }
             ]
         )

--- a/src/reporting/summary_tables.py
+++ b/src/reporting/summary_tables.py
@@ -319,9 +319,11 @@ def evaluate_historical_predictions(sample_size: int = 5) -> list[dict[str, Any]
                 "proposal_id": row.get(id_col),
                 "dao": row.get(dao_col, "Gov") if dao_col else "Gov",
                 "predicted": predicted,
-                "confidence": prob,
+                "confidence": forecast.get("confidence", prob),
                 "prediction_time": prediction_time,
-                "margin_of_error": forecast.get("turnout_estimate", 0.0),
+                "margin_of_error": forecast.get(
+                    "margin_of_error", forecast.get("turnout_estimate", 0.0)
+                ),
             }
         )
 

--- a/tests/test_outcome_forecaster.py
+++ b/tests/test_outcome_forecaster.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from src.agents import outcome_forecaster
 from src.agents.outcome_forecaster import forecast_outcomes
 from src.data_processing import referenda_updater
 
@@ -32,3 +33,45 @@ def test_probability_varies_with_comment_trend(monkeypatch):
         assert high > low
     else:
         assert high < low
+
+
+def test_fallback_forecast_uses_context(monkeypatch):
+    monkeypatch.setattr(
+        referenda_updater,
+        "load_historical_rates",
+        lambda: {"approval_rate": 0.5, "turnout": 0.5, "turnout_trend": 0.0},
+    )
+    monkeypatch.setattr(outcome_forecaster, "_load_model", lambda: None)
+
+    ctx_negative = {"sentiment_score": -0.4, "comment_turnout_trend": -0.3}
+    ctx_positive = {"sentiment_score": 0.4, "comment_turnout_trend": 0.3}
+
+    low = forecast_outcomes(ctx_negative)["approval_prob"]
+    high = forecast_outcomes(ctx_positive)["approval_prob"]
+    assert high > low
+
+
+def test_margin_and_confidence_reflect_context(monkeypatch):
+    monkeypatch.setattr(
+        referenda_updater,
+        "load_historical_rates",
+        lambda: {"approval_rate": 0.5, "turnout": 0.5, "turnout_trend": 0.05},
+    )
+    monkeypatch.setattr(outcome_forecaster, "_load_model", lambda: None)
+
+    calm_context = {
+        "source_sentiments": {"news": 0.1, "forum": 0.15},
+        "comment_turnout_trend": 0.02,
+        "engagement_weight": 0.9,
+    }
+    volatile_context = {
+        "source_sentiments": {"news": -0.4, "forum": 0.45},
+        "comment_turnout_trend": 0.25,
+        "engagement_weight": 0.1,
+    }
+
+    calm_result = forecast_outcomes(calm_context)
+    volatile_result = forecast_outcomes(volatile_context)
+
+    assert volatile_result["margin_of_error"] > calm_result["margin_of_error"]
+    assert volatile_result["confidence"] < calm_result["confidence"]

--- a/tests/test_prediction_analysis.py
+++ b/tests/test_prediction_analysis.py
@@ -21,9 +21,16 @@ def test_forecast_outcomes_fields_and_ranges(tmp_path, monkeypatch):
         "comment_turnout_trend": 0.05,
     }
     result = forecast_outcomes(context)
-    assert set(result.keys()) == {"approval_prob", "turnout_estimate"}
+    assert set(result.keys()) == {
+        "approval_prob",
+        "turnout_estimate",
+        "margin_of_error",
+        "confidence",
+    }
     assert 0.0 <= result["approval_prob"] <= 1.0
     assert 0.0 <= result["turnout_estimate"] <= 1.0
+    assert 0.0 <= result["confidence"] <= 1.0
+    assert 0.0 < result["margin_of_error"] <= 0.5
 
     model_path = Path(__file__).resolve().parents[1] / "models" / "referendum_model.json"
     with model_path.open() as f:


### PR DESCRIPTION
## Summary
- enhance the fallback outcome forecast to adjust approval probability with contextual sentiment, engagement, and turnout trends
- derive a draft-specific margin of error and confidence score from turnout volatility and sentiment dispersion
- update downstream consumers and extend tests to cover fallback behaviour and margin/confidence variability

## Testing
- pytest tests/test_outcome_forecaster.py tests/test_prediction_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68e230f167848322bd02ffc08b7fb51a